### PR TITLE
Fix data['data']['devices'] TypeError and windows error

### DIFF
--- a/custom_components/robovac_mqtt/__init__.py
+++ b/custom_components/robovac_mqtt/__init__.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+import sys
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -9,6 +11,8 @@ from .constants.hass import DOMAIN, VACS
 PLATFORMS = [Platform.VACUUM]
 _LOGGER = logging.getLogger(__name__)
 
+if sys.platform == 'win32':
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 async def async_setup(hass: HomeAssistant, _) -> bool:
     hass.data.setdefault(DOMAIN, {VACS: {}})

--- a/custom_components/robovac_mqtt/api/EufyApi.py
+++ b/custom_components/robovac_mqtt/api/EufyApi.py
@@ -95,7 +95,7 @@ class EufyApi:
             ) as response:
                 if response.status == 200:
                     data = await response.json()
-                    if data['data']['devices'] == 'None':  # TODO: does this work?
+                    if data['data']['devices'] == None:
                         _LOGGER.info('Found 0 devices via Eufy MQTT')
                         return []
                     device_array = [device['device'] for device in data['data']['devices']]


### PR DESCRIPTION
Addresses https://github.com/jeppesens/eufy-clean/issues/6#issuecomment-2690844390

This should hopefully fix @ScottWoolven5's issue with the `TypeError: 'NoneType' object is not iterable`. The code was comparing `'None'` when it should simply compare `None`. Alternatively, the line could simply read `if data['data']['devices']` but I felt the `== None` aids readability.

I also fixed an issue for local testing on Windows by adding the below - see details in aio-libs/aiodns#86. Without this change `example.py` cannot be run on a Windows machine.
```python
if sys.platform == 'win32':
    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
```

I am yet test on HomeAssistant if this works on my X8 Pro. I have tested locally and the device is found in the cloud codepath without an exception in the mqtt codepath.