### PR TITLE
Feat: Stateful Scene Selection

### DIFF
--- a/custom_components/robovac_mqtt/manifest.json
+++ b/custom_components/robovac_mqtt/manifest.json
@@ -12,5 +12,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/jeppesens/eufy-clean/issues",
     "requirements": [],
-    "version": "1.4.1"
+    "version": "1.5.0"
 }

--- a/custom_components/robovac_mqtt/models.py
+++ b/custom_components/robovac_mqtt/models.py
@@ -63,6 +63,8 @@ class VacuumState:
     station_waste_water: int = 0
     dock_auto_cfg: dict[str, Any] = field(default_factory=dict)
     trigger_source: str = "unknown"
+    current_scene_id: int = 0
+    current_scene_name: str | None = None
 
     # Accessories
     accessories: AccessoryState = field(default_factory=AccessoryState)

--- a/custom_components/robovac_mqtt/select.py
+++ b/custom_components/robovac_mqtt/select.py
@@ -226,7 +226,22 @@ class SceneSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
 
     @property
     def current_option(self) -> str | None:
-        """Scenes are action-triggers, they don't have a persistent 'current' state."""
+        """Return the currently active scene."""
+        # Check by ID first if we have a scene running
+        current_id = self.coordinator.data.current_scene_id
+        if current_id > 0:
+            # Try to match by ID in the list to return the name from the list
+            # This ensures we return a valid option even if the name format varies slightly
+            scene = next(
+                (s for s in self.coordinator.data.scenes if s["id"] == current_id), None
+            )
+            if scene:
+                return f"{scene.get('name') or 'Scene'} (ID: {scene['id']})"
+
+            # Fallback to reported name if available (even if not in options list)
+            if self.coordinator.data.current_scene_name:
+                return f"{self.coordinator.data.current_scene_name} (ID: {current_id})"
+
         return None
 
     async def async_select_option(self, option: str) -> None:

--- a/tests/test_scene_state.py
+++ b/tests/test_scene_state.py
@@ -1,0 +1,120 @@
+from unittest.mock import MagicMock
+
+from custom_components.robovac_mqtt.api.parser import update_state
+from custom_components.robovac_mqtt.const import DPS_MAP
+from custom_components.robovac_mqtt.models import VacuumState
+from custom_components.robovac_mqtt.proto.cloud.work_status_pb2 import WorkStatus
+from custom_components.robovac_mqtt.select import SceneSelectEntity
+from custom_components.robovac_mqtt.utils import encode_message
+
+
+def test_scene_select_entity_mocked():
+    """Test SceneSelectEntity with mocked coordinator."""
+
+    # 1. Setup Mock Coordinator
+    mock_coordinator = MagicMock()
+    mock_coordinator.device_id = "test_id"
+    mock_coordinator.device_info = {}
+    mock_coordinator.data = VacuumState()
+
+    # Pre-populate available scenes
+    mock_coordinator.data.scenes = [
+        {"id": 1, "name": "Living Room"},
+        {"id": 8, "name": "Hallway test"},
+    ]
+
+    entity = SceneSelectEntity(mock_coordinator)
+    entity.hass = MagicMock()
+
+    # 2. Test Initial State (None)
+    assert entity.current_option is None
+
+    # 3. Simulate Scene Active (ID Match)
+    mock_coordinator.data.current_scene_id = 8
+    mock_coordinator.data.current_scene_name = "Hallway test"
+
+    assert entity.current_option == "Hallway test (ID: 8)"
+
+    # 4. Simulate Scene Active (No Name in List, use reported name)
+    mock_coordinator.data.current_scene_id = 99
+    mock_coordinator.data.current_scene_name = "New Scene"
+
+    # Should use the reported name as fallback with ID
+    assert entity.current_option == "New Scene (ID: 99)"
+
+    # 5. Simulate Scene Inactive (ID=0)
+    mock_coordinator.data.current_scene_id = 0
+    mock_coordinator.data.current_scene_name = None
+
+    assert entity.current_option is None
+
+
+def test_scene_parsing_logic():
+    """Test extracting scene info from WorkStatus proto."""
+    ws = WorkStatus()
+    ws.current_scene.id = 8
+    ws.current_scene.name = "Hallway test"
+
+    encoded = encode_message(ws)
+    mock_dps = {DPS_MAP["WORK_STATUS"]: encoded}
+
+    state_obj = VacuumState()
+    _, changes = update_state(state_obj, mock_dps)
+
+    assert changes.get("current_scene_id") == 8
+    assert changes.get("current_scene_name") == "Hallway test"
+
+
+def test_scene_parsing_partial_update():
+    """Test response when WorkStatus partial update (omitted fields) arrives."""
+    ws = WorkStatus()
+    # No mode, no state (default 0), no current_scene
+    # This simulates a partial update like 'station' only
+
+    encoded = encode_message(ws)
+    mock_dps = {DPS_MAP["WORK_STATUS"]: encoded}
+
+    state_obj = VacuumState()
+    # Pre-set state to simulate active scene
+    state_obj.current_scene_id = 9
+    state_obj.current_scene_name = "Old"
+
+    _, changes = update_state(state_obj, mock_dps)
+
+    # Should NOT be in changes dict (preserving old state)
+    assert "current_scene_id" not in changes
+    assert "current_scene_name" not in changes
+
+
+def test_scene_parsing_explicit_clear_mode():
+    """Test clearing scene when Mode changes to Auto."""
+    ws = WorkStatus()
+    ws.mode.value = 0  # AUTO
+
+    encoded = encode_message(ws)
+    mock_dps = {DPS_MAP["WORK_STATUS"]: encoded}
+
+    state_obj = VacuumState()
+    state_obj.current_scene_id = 9
+
+    _, changes = update_state(state_obj, mock_dps)
+
+    assert changes.get("current_scene_id") == 0
+    assert changes.get("current_scene_name") is None
+
+
+def test_scene_parsing_explicit_clear_state():
+    """Test clearing scene when State changes to Charging."""
+    ws = WorkStatus()
+    ws.state = 3  # CHARGING
+
+    encoded = encode_message(ws)
+    mock_dps = {DPS_MAP["WORK_STATUS"]: encoded}
+
+    state_obj = VacuumState()
+    state_obj.current_scene_id = 9
+
+    _, changes = update_state(state_obj, mock_dps)
+
+    assert changes.get("current_scene_id") == 0
+    assert changes.get("current_scene_name") is None


### PR DESCRIPTION
## Overview
This PR enhances the **Scene Selection** entity to be fully **stateful**. Users can now see exactly which scene is currently running in Home Assistant, and the state persists correctly throughout the cleaning session.
Previously, the Scene Selector was a stateless "trigger-only" control that would revert to "Unknown" immediately after activation.

closes #83 

## Key Changes
- **Stateful Entity**: The [SceneSelectEntity](cci:2://file:///workspaces/eufy-clean/custom_components/robovac_mqtt/select.py:207:0-266:35) now reports the active scene (e.g., `"Hallway test (ID: 8)"`) instead of reporting `Unknown`.
- **Robust State Tracking**: Implemented "sticky" state logic in the protobuf parser. This ensures the scene state remains valid even when the robot sends partial MQTT updates (like battery or sensor status) that naturally omit scene information.
- **Auto-Clearing**: The scene state is automatically cleared when the robot finishes the task, returns to the dock, or switches to a different mode (e.g., Auto Clean).
## Verification
- Added comprehensive unit tests in [tests/test_scene_state.py](cci:7://file:///workspaces/eufy-clean/tests/test_scene_state.py:0:0-0:0) to verify parsing, persistence, and state clearing logic.
- Verified manually that scene names persist correctly in the Home Assistant UI during operation.