### PR TITLE
implement vacuum.locate

### DIFF
--- a/custom_components/robovac_mqtt/vacuum.py
+++ b/custom_components/robovac_mqtt/vacuum.py
@@ -62,6 +62,7 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
             | VacuumEntityFeature.FAN_SPEED
             | VacuumEntityFeature.RETURN_HOME
             | VacuumEntityFeature.SEND_COMMAND
+            | VacuumEntityFeature.LOCATE
         )
 
     @property
@@ -137,6 +138,12 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
 
         await self.coordinator.async_send_command(
             build_command("set_fan_speed", fan_speed=fan_speed)
+        )
+
+    async def async_locate(self, **kwargs: Any) -> None:
+        """Locate the vacuum cleaner."""
+        await self.coordinator.async_send_command(
+            build_command("find_robot", active=True)
         )
 
     async def async_send_command(

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -98,6 +98,10 @@ async def test_vacuum_commands(mock_coordinator):
         await entity.async_clean_spot()
         mock_build.assert_called_with("clean_spot")
 
+        # Locate
+        await entity.async_locate()
+        mock_build.assert_called_with("find_robot", active=True)
+
 
 @pytest.mark.asyncio
 async def test_set_fan_speed(mock_coordinator):


### PR DESCRIPTION
This PR implements native support for the `vacuum.locate` service, allowing the vacuum to be located via standard Home Assistant service calls.

closes #87 
### Changes
- Implemented [async_locate](cci:1://file:///workspaces/eufy-clean/custom_components/robovac_mqtt/vacuum.py:142:4-146:9) in [vacuum.py](cci:7://file:///workspaces/eufy-clean/tests/test_vacuum.py:0:0-0:0).
- Added `VacuumEntityFeature.LOCATE` to supported features.
- Added unit tests for the new action.