### PR TITLE
fix: use Android user-agent for login to fix 403 from Eufy API

### DIFF
--- a/custom_components/robovac_mqtt/api/http.py
+++ b/custom_components/robovac_mqtt/api/http.py
@@ -51,7 +51,7 @@ class EufyHTTPClient:
                     "openudid": self.openudid,
                     "Content-Type": "application/json",
                     "clientType": "1",
-                    "User-Agent": "EufyHome-iOS-2.14.0-6",
+                    "User-Agent": "EufyHome-Android-3.1.3-753",
                     "Connection": "keep-alive",
                 },
                 json={
@@ -67,7 +67,11 @@ class EufyHTTPClient:
                         _LOGGER.debug("eufyLogin successful")
                         self.session = response_json
                         return response_json
-                _LOGGER.error("Login failed: %s", await response.json())
+                try:
+                    body = await response.json()
+                except Exception:
+                    body = await response.text()
+                _LOGGER.error("Login failed: %s %s", response.status, body)
                 return None
 
     async def get_user_info(self) -> dict[str, Any] | None:


### PR DESCRIPTION
The Eufy home-api.eufylife.com login endpoint now returns 403 Forbidden when the iOS user-agent (`EufyHome-iOS-2.14.0-6`) is used. Switching to the Android user-agent (`EufyHome-Android-3.1.3-753`), which is already used by [all other API calls](https://github.com/search?q=repo%3Ajeppesens%2Feufy-clean%20EufyHome-Android-3.1.3-753&type=code), resolves the issue.

Also fix error handling in eufy_login() to gracefully handle non-JSON error responses instead of raising a ContentTypeError from aiohttp.

Fixes #93