### PR TITLE
Restore scene and room IDs in select dropdowns

### DIFF
--- a/custom_components/robovac_mqtt/select.py
+++ b/custom_components/robovac_mqtt/select.py
@@ -23,9 +23,13 @@ from .const import (
     EUFY_CLEAN_WATER_LEVELS,
 )
 from .coordinator import EufyCleanCoordinator
-from .utils import deduplicate_names
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _format_option_label(item: dict[str, Any], default_name: str) -> str:
+    """Format a select option label as '<name> (ID: <id>)'."""
+    return f"{item.get('name') or default_name} (ID: {item['id']})"
 
 
 _MOP_INTENSITY_TO_WATER_LEVEL = {
@@ -254,43 +258,35 @@ class SceneSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
     @property
     def options(self) -> list[str]:
         """Return available scenes."""
-        names = [s["name"] for s in self.coordinator.data.scenes if "name" in s]
-        return deduplicate_names(names)
+        return [_format_option_label(s, "Scene") for s in self.coordinator.data.scenes]
 
     @property
     def current_option(self) -> str | None:
         """Return the currently active scene."""
         current_id = self.coordinator.data.current_scene_id
         if current_id > 0:
-            named_scenes = [s for s in self.coordinator.data.scenes if "name" in s]
-            for idx, scene in enumerate(named_scenes):
+            for scene in self.coordinator.data.scenes:
                 if scene["id"] == current_id:
-                    options = self.options
-                    if idx < len(options):
-                        return options[idx]
-                    return None
+                    return _format_option_label(scene, "Scene")
 
             # Fallback to reported name if available (even if not in options list)
             if self.coordinator.data.current_scene_name:
-                return self.coordinator.data.current_scene_name
+                return f"{self.coordinator.data.current_scene_name} (ID: {current_id})"
 
         return None
 
     async def async_select_option(self, option: str) -> None:
         """Trigger the selected scene."""
-        # Match by index in the deduplicated options list to handle duplicate names
-        try:
-            idx = self.options.index(option)
-        except ValueError:
+        scenes = self.coordinator.data.scenes
+        scene = next(
+            (s for s in scenes if _format_option_label(s, "Scene") == option),
+            None,
+        )
+        if not scene:
             _LOGGER.error("Scene '%s' not found", option)
             return
 
-        named_scenes = [s for s in self.coordinator.data.scenes if "name" in s]
-        if idx >= len(named_scenes):
-            _LOGGER.error("Scene '%s' index out of range", option)
-            return
-
-        scene_id = named_scenes[idx]["id"]
+        scene_id = scene["id"]
         _LOGGER.info("Triggering scene '%s' (ID: %s)", option, scene_id)
 
         command = build_command("scene_clean", scene_id=scene_id)
@@ -316,8 +312,7 @@ class RoomSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
     @property
     def options(self) -> list[str]:
         """Return available rooms."""
-        names = [r["name"] for r in self.coordinator.data.rooms if "name" in r]
-        return deduplicate_names(names)
+        return [_format_option_label(r, "Room") for r in self.coordinator.data.rooms]
 
     @property
     def current_option(self) -> str | None:
@@ -326,19 +321,16 @@ class RoomSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Trigger cleaning of the selected room."""
-        # Match by index in the deduplicated options list to handle duplicate names
-        try:
-            idx = self.options.index(option)
-        except ValueError:
+        rooms = self.coordinator.data.rooms
+        room = next(
+            (r for r in rooms if _format_option_label(r, "Room") == option),
+            None,
+        )
+        if not room:
             _LOGGER.error("Room '%s' not found", option)
             return
 
-        named_rooms = [r for r in self.coordinator.data.rooms if "name" in r]
-        if idx >= len(named_rooms):
-            _LOGGER.error("Room '%s' index out of range", option)
-            return
-
-        room_id = named_rooms[idx]["id"]
+        room_id = room["id"]
         # Use discovered map_id if available, otherwise fallback to 1
         map_id = self.coordinator.data.map_id or 1
         _LOGGER.info(

--- a/tests/test_scene_state.py
+++ b/tests/test_scene_state.py
@@ -33,14 +33,14 @@ def test_scene_select_entity_mocked():
     mock_coordinator.data.current_scene_id = 8
     mock_coordinator.data.current_scene_name = "Hallway test"
 
-    assert entity.current_option == "Hallway test"
+    assert entity.current_option == "Hallway test (ID: 8)"
 
     # 4. Simulate Scene Active (No Name in List, use reported name)
     mock_coordinator.data.current_scene_id = 99
     mock_coordinator.data.current_scene_name = "New Scene"
 
-    # Should use the reported name as fallback without ID now
-    assert entity.current_option == "New Scene"
+    # Should use the reported name as fallback with ID
+    assert entity.current_option == "New Scene (ID: 99)"
 
     # 5. Simulate Scene Inactive (ID=0)
     mock_coordinator.data.current_scene_id = 0

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -148,13 +148,13 @@ async def test_scene_select_entity(mock_coordinator):
     entity.async_write_ha_state = MagicMock()
 
     assert entity.name == "Scene"
-    assert entity.options == ["Scene 1", "Scene 2"]
+    assert entity.options == ["Scene 1 (ID: 1)", "Scene 2 (ID: 2)"]
     assert entity.current_option is None
 
     with patch("custom_components.robovac_mqtt.select.build_command") as mock_build:
         mock_build.return_value = {"cmd": "scene_cmd"}
 
-        await entity.async_select_option("Scene 2")
+        await entity.async_select_option("Scene 2 (ID: 2)")
 
         mock_build.assert_called_with("scene_clean", scene_id=2)
         mock_coordinator.async_send_command.assert_called_with({"cmd": "scene_cmd"})
@@ -174,15 +174,13 @@ async def test_room_select_entity(mock_coordinator):
     entity.async_write_ha_state = MagicMock()
 
     assert entity.name == "Clean Room"
-    # Matches format "Name"
-    assert "Kitchen" in entity.options
-    assert "Living Room" in entity.options
+    assert entity.options == ["Kitchen (ID: 10)", "Living Room (ID: 12)"]
     assert entity.current_option is None
 
     with patch("custom_components.robovac_mqtt.select.build_command") as mock_build:
         mock_build.return_value = {"cmd": "room_cmd"}
 
-        await entity.async_select_option("Kitchen")
+        await entity.async_select_option("Kitchen (ID: 10)")
 
         mock_build.assert_called_with(
             "room_clean", room_ids=[10], map_id=5
@@ -347,8 +345,8 @@ def test_dock_select_unavailable_no_cfg(mock_coordinator):
     assert entity.available is False
 
 
-def test_scene_select_current_option_dedup(mock_coordinator):
-    """Test current_option returns deduplicated name for duplicate scene names."""
+def test_scene_select_current_option_with_id(mock_coordinator):
+    """Test current_option includes ID even for duplicate scene names."""
     mock_coordinator.data.scenes = [
         {"id": 1, "name": "Clean"},
         {"id": 2, "name": "Clean"},
@@ -357,8 +355,7 @@ def test_scene_select_current_option_dedup(mock_coordinator):
     mock_coordinator.data.current_scene_name = "Clean"
 
     entity = SceneSelectEntity(mock_coordinator)
-    # The second "Clean" should be returned as "Clean (2)" to match options
-    assert entity.current_option == "Clean (2)"
+    assert entity.current_option == "Clean (ID: 2)"
 
 
 # ── Select Entity Availability Tests ─────────────────────────────────


### PR DESCRIPTION
## Summary
- Restores the `(ID: X)` suffix in Scene and Room select dropdown labels, which was unintentionally removed in v1.8.0
- Users can now find scene/room IDs directly in the HA UI for use in automations

Fixes #112

<img width="444" height="539" alt="image" src="https://github.com/user-attachments/assets/a6406d90-43a4-404b-b26c-05e7209d4930" />


## Test plan
- [ ] Verify Scene dropdown shows labels like `Kitchen - Standard (ID: 8)`
- [ ] Verify Room dropdown shows labels like `Kitchen (ID: 10)`
- [ ] Verify selecting a scene/room still triggers the correct command
- [ ] All 170 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)