### PR TITLE
Add device info sensors, active cleaning targets, and DPS 179 telemetry

### DIFF
--- a/custom_components/robovac_mqtt/__init__.py
+++ b/custom_components/robovac_mqtt/__init__.py
@@ -21,6 +21,7 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.NUMBER,
     Platform.BINARY_SENSOR,
+    Platform.TIME,
 ]
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/robovac_mqtt/api/commands.py
+++ b/custom_components/robovac_mqtt/api/commands.py
@@ -17,6 +17,7 @@ from ..proto.cloud.consumable_pb2 import ConsumableRequest
 from ..proto.cloud.control_pb2 import ModeCtrlRequest, SelectRoomsClean
 from ..proto.cloud.map_edit_pb2 import MapEditRequest
 from ..proto.cloud.station_pb2 import StationRequest
+from ..proto.cloud.unisetting_pb2 import UnisettingRequest
 from ..utils import encode, encode_message
 
 _LOGGER = logging.getLogger(__name__)
@@ -288,6 +289,12 @@ def build_find_robot_command(active: bool) -> dict[str, Any]:
     return {DPS_MAP["FIND_ROBOT"]: active}
 
 
+def build_set_child_lock_command(active: bool) -> dict[str, str]:
+    """Build command to toggle the child lock setting."""
+    value = encode(UnisettingRequest, {"children_lock": {"value": active}})
+    return {DPS_MAP["UNSETTING"]: value}
+
+
 def build_command(command: str, **kwargs: Any) -> dict[str, Any]:
     """Unified command builder."""
     cmd = command.lower()
@@ -352,5 +359,7 @@ def build_command(command: str, **kwargs: Any) -> dict[str, Any]:
         return build_set_auto_action_cfg_command(kwargs.get("cfg", {}))
     if cmd == "reset_accessory":
         return build_reset_accessory_command(int(kwargs.get("reset_type", 0)))
+    if cmd == "set_child_lock":
+        return build_set_child_lock_command(bool(kwargs.get("active", True)))
 
     return {}

--- a/custom_components/robovac_mqtt/api/commands.py
+++ b/custom_components/robovac_mqtt/api/commands.py
@@ -17,6 +17,7 @@ from ..proto.cloud.consumable_pb2 import ConsumableRequest
 from ..proto.cloud.control_pb2 import ModeCtrlRequest, SelectRoomsClean
 from ..proto.cloud.map_edit_pb2 import MapEditRequest
 from ..proto.cloud.station_pb2 import StationRequest
+from ..proto.cloud.undisturbed_pb2 import UndisturbedRequest
 from ..proto.cloud.unisetting_pb2 import UnisettingRequest
 from ..utils import encode, encode_message
 
@@ -295,6 +296,27 @@ def build_set_child_lock_command(active: bool) -> dict[str, str]:
     return {DPS_MAP["UNSETTING"]: value}
 
 
+def build_set_undisturbed_command(
+    active: bool,
+    begin_hour: int,
+    begin_minute: int,
+    end_hour: int,
+    end_minute: int,
+) -> dict[str, str]:
+    """Build command to update the Do Not Disturb schedule."""
+    value = encode(
+        UndisturbedRequest,
+        {
+            "undisturbed": {
+                "sw": {"value": active},
+                "begin": {"hour": begin_hour, "minute": begin_minute},
+                "end": {"hour": end_hour, "minute": end_minute},
+            }
+        },
+    )
+    return {DPS_MAP["UNDISTURBED"]: value}
+
+
 def build_command(command: str, **kwargs: Any) -> dict[str, Any]:
     """Unified command builder."""
     cmd = command.lower()
@@ -361,5 +383,13 @@ def build_command(command: str, **kwargs: Any) -> dict[str, Any]:
         return build_reset_accessory_command(int(kwargs.get("reset_type", 0)))
     if cmd == "set_child_lock":
         return build_set_child_lock_command(bool(kwargs.get("active", True)))
+    if cmd == "set_do_not_disturb":
+        return build_set_undisturbed_command(
+            bool(kwargs.get("active", True)),
+            int(kwargs.get("begin_hour", 22)),
+            int(kwargs.get("begin_minute", 0)),
+            int(kwargs.get("end_hour", 8)),
+            int(kwargs.get("end_minute", 0)),
+        )
 
     return {}

--- a/custom_components/robovac_mqtt/api/parser.py
+++ b/custom_components/robovac_mqtt/api/parser.py
@@ -515,7 +515,11 @@ def _process_other_dps(
                     _track_field(state, changes, "robot_position")
 
             elif key in KNOWN_UNPROCESSED_DPS:
-                pass  # Acknowledged; value already in raw_dps
+                _LOGGER.debug(
+                    "Known unprocessed DPS %s: %s (value stored in raw_dps)",
+                    key,
+                    value,
+                )
 
             else:
                 _LOGGER.debug("Received unhandled DPS %s: %s", key, value)

--- a/custom_components/robovac_mqtt/api/parser.py
+++ b/custom_components/robovac_mqtt/api/parser.py
@@ -569,6 +569,7 @@ def _map_task_status(status: WorkStatus, dock_status: str | None = None) -> str:
                 "Recycling waste water",
             ):
                 return "Washing Mop"
+            return "Paused"
 
         # If not resumable and cleaning field is absent, the task is complete
         if status.HasField("station") and status.station.HasField(

--- a/custom_components/robovac_mqtt/api/parser.py
+++ b/custom_components/robovac_mqtt/api/parser.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import base64
 import logging
 from dataclasses import replace
 from typing import Any
 
+from google.protobuf.internal.decoder import _DecodeVarint
 from google.protobuf.json_format import MessageToDict
 
 from ..const import (
@@ -13,10 +15,12 @@ from ..const import (
     CORNER_CLEANING_NAMES,
     DOCK_ACTIVITY_STATES,
     DPS_MAP,
+    DPS_ROBOT_TELEMETRY,
     EUFY_CLEAN_APP_TRIGGER_MODES,
     EUFY_CLEAN_ERROR_CODES,
     EUFY_CLEAN_NOVEL_CLEAN_SPEED,
     FAN_SUCTION_NAMES,
+    KNOWN_UNPROCESSED_DPS,
     MOP_WATER_LEVEL_NAMES,
     TRIGGER_SOURCE_NAMES,
     WORK_MODE_NAMES,
@@ -25,21 +29,73 @@ from ..const import (
     TriggerSource,
 )
 from ..models import AccessoryState, VacuumState
-from ..proto.cloud.clean_param_pb2 import (
-    CleanParamRequest,
-    CleanParamResponse,
-)
+from ..proto.cloud.app_device_info_pb2 import DeviceInfo
+from ..proto.cloud.clean_param_pb2 import CleanParamRequest, CleanParamResponse
 from ..proto.cloud.clean_statistics_pb2 import CleanStatistics
 from ..proto.cloud.consumable_pb2 import ConsumableResponse
+from ..proto.cloud.control_pb2 import ModeCtrlRequest
 from ..proto.cloud.error_code_pb2 import ErrorCode
 from ..proto.cloud.scene_pb2 import SceneResponse
 from ..proto.cloud.station_pb2 import StationResponse
+from ..proto.cloud.multi_maps_pb2 import MultiMapsManageResponse
 from ..proto.cloud.stream_pb2 import RoomParams
+from ..proto.cloud.unisetting_pb2 import UnisettingResponse
 from ..proto.cloud.universal_data_pb2 import UniversalDataResponse
 from ..proto.cloud.work_status_pb2 import WorkStatus
 from ..utils import decode, deduplicate_names
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _decode_raw_varints(data: bytes) -> dict[int, int | bytes]:
+    """Decode raw protobuf fields from bytes (no schema needed).
+
+    Returns a dict of field_number -> value (int for varints, bytes for
+    length-delimited fields).
+    """
+    fields: dict[int, int | bytes] = {}
+    i = 0
+    while i < len(data):
+        tag, i = _DecodeVarint(data, i)
+        fn, wt = tag >> 3, tag & 7
+        if wt == 0:  # varint
+            val, i = _DecodeVarint(data, i)
+            fields[fn] = val
+        elif wt == 2:  # length-delimited
+            blen, i = _DecodeVarint(data, i)
+            fields[fn] = data[i : i + blen]
+            i += blen
+        else:
+            break
+    return fields
+
+
+def _parse_robot_telemetry(value: str) -> dict[str, Any] | None:
+    """Parse DPS 179 robot telemetry (no proto definition available).
+
+    Wire format: varint-length-prefixed message containing:
+      field 2 (bytes) -> sub-message with field 7 (bytes) -> inner message:
+        field 1: uint32  Unix timestamp
+        field 2: uint32  battery percentage
+        field 3: uint32  unknown (slowly increasing value)
+        field 4: uint32  map X coordinate
+        field 5: uint32  map Y coordinate
+        field 6: bytes   additional data (2 packed varints)
+    """
+    raw = base64.b64decode(value)
+    _length, pos = _DecodeVarint(raw, 0)
+    outer = _decode_raw_varints(raw[pos:])
+    sub_bytes = outer.get(2)
+    if not isinstance(sub_bytes, bytes):
+        return None
+    sub = _decode_raw_varints(sub_bytes)
+    inner_bytes = sub.get(7)
+    if not isinstance(inner_bytes, bytes):
+        return None
+    inner = _decode_raw_varints(inner_bytes)
+    if 4 not in inner or 5 not in inner:
+        return None
+    return {"x": inner[4], "y": inner[5]}
 
 
 def _track_field(state: VacuumState, changes: dict[str, Any], field_name: str) -> None:
@@ -77,6 +133,7 @@ def update_state(
     # Helper functions to process specific DPS groups
     _process_station_status(state, dps, changes)
     _process_work_status(state, dps, changes)
+    _process_play_pause(state, dps, changes)
     _process_other_dps(state, dps, changes)
 
     # Log received_fields for debugging sensor availability
@@ -238,8 +295,52 @@ def _process_work_status(
             changes["current_scene_id"] = 0
             changes["current_scene_name"] = None
 
+        # Clear active cleaning targets when no longer actively cleaning
+        activity = changes.get("activity")
+        if activity in ("idle", "docked", "error"):
+            if state.active_room_ids or state.active_zone_count:
+                changes["active_room_ids"] = []
+                changes["active_room_names"] = ""
+                changes["active_zone_count"] = 0
+
     except Exception as e:
         _LOGGER.warning("Error parsing Work Status: %s", e, exc_info=True)
+
+
+def _process_play_pause(
+    state: VacuumState, dps: dict[str, Any], changes: dict[str, Any]
+) -> None:
+    """Process Play/Pause DPS (152) - extract active cleaning targets."""
+    if DPS_MAP["PLAY_PAUSE"] not in dps:
+        return
+
+    value = dps[DPS_MAP["PLAY_PAUSE"]]
+    try:
+        mode_ctrl = decode(ModeCtrlRequest, value)
+        _LOGGER.debug("Decoded ModeCtrlRequest: %s", mode_ctrl)
+
+        if mode_ctrl.HasField("select_rooms_clean"):
+            room_ids = [r.id for r in mode_ctrl.select_rooms_clean.rooms]
+            changes["active_room_ids"] = room_ids
+            room_lookup = {
+                r["id"]: r.get("name", f"Room {r['id']}") for r in state.rooms
+            }
+            names = [room_lookup.get(rid, f"Room {rid}") for rid in room_ids]
+            changes["active_room_names"] = ", ".join(names)
+            changes["active_zone_count"] = 0
+            _track_field(state, changes, "active_room_ids")
+
+        elif mode_ctrl.HasField("select_zones_clean"):
+            changes["active_zone_count"] = len(mode_ctrl.select_zones_clean.zones)
+            changes["active_room_ids"] = []
+            changes["active_room_names"] = ""
+            _track_field(state, changes, "active_room_ids")
+
+        # Scene: intentionally skipped (already tracked via WorkStatus.current_scene)
+        # Control commands (pause/resume/stop): no Param oneof, naturally ignored
+
+    except Exception as e:
+        _LOGGER.warning("Error parsing Play/Pause DPS: %s", e, exc_info=True)
 
 
 def _process_other_dps(
@@ -248,7 +349,7 @@ def _process_other_dps(
     """Process other DPS items."""
     for key, value in dps.items():
         # Specialized keys are handled in their respective functions
-        if key in (DPS_MAP["WORK_STATUS"], DPS_MAP["STATION_STATUS"]):
+        if key in (DPS_MAP["WORK_STATUS"], DPS_MAP["STATION_STATUS"], DPS_MAP["PLAY_PAUSE"]):
             continue
 
         try:
@@ -305,6 +406,68 @@ def _process_other_dps(
 
             elif key == DPS_MAP["FIND_ROBOT"]:
                 changes["find_robot"] = str(value).lower() == "true"
+
+            elif key == DPS_MAP["MAP_MANAGE"]:
+                # DPS 169 carries DeviceInfo proto (not map data despite the name).
+                # Contains firmware version, WiFi SSID/IP, station firmware, MAC.
+                # Firmware version is already in the HA device registry via
+                # coordinator.device_info (sw_version from cloud API), so we
+                # only extract network info here.
+                info = decode(DeviceInfo, value)
+                _LOGGER.debug("Decoded DeviceInfo: %s", info)
+                if info.device_mac:
+                    changes["device_mac"] = info.device_mac
+                if info.wifi_name:
+                    changes["wifi_ssid"] = info.wifi_name
+                    _track_field(state, changes, "wifi_ssid")
+                if info.wifi_ip:
+                    changes["wifi_ip"] = info.wifi_ip
+                    _track_field(state, changes, "wifi_ip")
+
+            elif key == DPS_MAP["MULTI_MAP_MANAGE"]:
+                if value is None:
+                    _LOGGER.debug("DPS 172: None value (initial state)")
+                else:
+                    _LOGGER.debug("Received MULTI_MAP_MANAGE (DPS 172): %.100s", value)
+                    map_result = _parse_multi_map_response(value)
+                    if map_result:
+                        changes.update(map_result)
+                        _track_field(state, changes, "map_image")
+
+            elif key == DPS_MAP["UNSETTING"]:
+                settings = decode(UnisettingResponse, value)
+                _LOGGER.debug("Decoded UnisettingResponse: %s", settings)
+                # Device reports 0-100%, approximate to dBm for HA convention
+                changes["wifi_signal"] = (settings.ap_signal_strength / 2) - 100
+                _track_field(state, changes, "wifi_signal")
+                if settings.HasField("children_lock"):
+                    changes["child_lock"] = settings.children_lock.value
+                    _track_field(state, changes, "child_lock")
+
+            elif key == DPS_ROBOT_TELEMETRY:
+                pos = _parse_robot_telemetry(value)
+                _LOGGER.debug(
+                    "DPS 179 telemetry: parsed=%s, raw_b64=%.60s...",
+                    pos, value,
+                )
+                if pos:
+                    raw_x, raw_y = pos["x"], pos["y"]
+                    changes["robot_position_x"] = raw_x
+                    changes["robot_position_y"] = raw_y
+                    _track_field(state, changes, "robot_position")
+
+                    # Capture dock reference when robot is docked
+                    cur_activity = changes.get("activity", state.activity)
+                    if cur_activity == "docked":
+                        changes["dock_ref_x"] = raw_x
+                        changes["dock_ref_y"] = raw_y
+
+                    # NOTE: relative position (robot_rel_x/y) is computed
+                    # by the coordinator using configurable scale + rotation.
+                    # Parser only extracts raw coordinates and dock reference.
+
+            elif key in KNOWN_UNPROCESSED_DPS:
+                pass  # Acknowledged; value already in raw_dps
 
             else:
                 _LOGGER.debug("Received unhandled DPS %s: %s", key, value)
@@ -575,6 +738,25 @@ def _parse_map_data(value: Any) -> dict[str, Any] | None:
 
     _LOGGER.debug("Failed to parse map data. Raw: %s", value)
     return None
+
+
+def _parse_multi_map_response(value: Any) -> dict[str, Any] | None:
+    """Parse MultiMapsManageResponse from DPS 172.
+
+    Note: MAP_GET_ALL/MAP_GET_ONE responses with pixel data are only
+    delivered via P2P, not cloud MQTT. This handler logs the response
+    metadata for diagnostics but currently cannot extract pixel data.
+    """
+    try:
+        resp = decode(MultiMapsManageResponse, value)
+        _LOGGER.debug(
+            "Decoded MultiMapsManageResponse: method=%s, result=%s",
+            resp.method, resp.result,
+        )
+        return None
+    except Exception as e:
+        _LOGGER.debug("MultiMapsManageResponse parse failed: %s", e)
+        return None
 
 
 def _parse_accessories(current_state: AccessoryState, value: Any) -> AccessoryState:

--- a/custom_components/robovac_mqtt/api/parser.py
+++ b/custom_components/robovac_mqtt/api/parser.py
@@ -35,9 +35,9 @@ from ..proto.cloud.clean_statistics_pb2 import CleanStatistics
 from ..proto.cloud.consumable_pb2 import ConsumableResponse
 from ..proto.cloud.control_pb2 import ModeCtrlRequest
 from ..proto.cloud.error_code_pb2 import ErrorCode
+from ..proto.cloud.multi_maps_pb2 import MultiMapsManageResponse
 from ..proto.cloud.scene_pb2 import SceneResponse
 from ..proto.cloud.station_pb2 import StationResponse
-from ..proto.cloud.multi_maps_pb2 import MultiMapsManageResponse
 from ..proto.cloud.stream_pb2 import RoomParams
 from ..proto.cloud.unisetting_pb2 import UnisettingResponse
 from ..proto.cloud.universal_data_pb2 import UniversalDataResponse
@@ -349,7 +349,11 @@ def _process_other_dps(
     """Process other DPS items."""
     for key, value in dps.items():
         # Specialized keys are handled in their respective functions
-        if key in (DPS_MAP["WORK_STATUS"], DPS_MAP["STATION_STATUS"], DPS_MAP["PLAY_PAUSE"]):
+        if key in (
+            DPS_MAP["WORK_STATUS"],
+            DPS_MAP["STATION_STATUS"],
+            DPS_MAP["PLAY_PAUSE"],
+        ):
             continue
 
         try:
@@ -448,7 +452,8 @@ def _process_other_dps(
                 pos = _parse_robot_telemetry(value)
                 _LOGGER.debug(
                     "DPS 179 telemetry: parsed=%s, raw_b64=%.60s...",
-                    pos, value,
+                    pos,
+                    value,
                 )
                 if pos:
                     raw_x, raw_y = pos["x"], pos["y"]
@@ -751,7 +756,8 @@ def _parse_multi_map_response(value: Any) -> dict[str, Any] | None:
         resp = decode(MultiMapsManageResponse, value)
         _LOGGER.debug(
             "Decoded MultiMapsManageResponse: method=%s, result=%s",
-            resp.method, resp.result,
+            resp.method,
+            resp.result,
         )
         return None
     except Exception as e:

--- a/custom_components/robovac_mqtt/api/parser.py
+++ b/custom_components/robovac_mqtt/api/parser.py
@@ -296,6 +296,14 @@ def _process_work_status(
         if work_status.HasField("current_scene"):
             changes["current_scene_id"] = work_status.current_scene.id
             changes["current_scene_name"] = work_status.current_scene.name
+            if (
+                state.active_room_ids
+                or state.active_room_names
+                or state.active_zone_count
+            ):
+                changes["active_room_ids"] = []
+                changes["active_room_names"] = ""
+                changes["active_zone_count"] = 0
 
         # 2. If explicit Mode provided and it's NOT Scene (8), clear it.
         # 8 = SCENE mode
@@ -309,9 +317,19 @@ def _process_work_status(
             changes["current_scene_id"] = 0
             changes["current_scene_name"] = None
 
-        # Clear active cleaning targets when no longer actively cleaning
+        # Clear active cleaning targets when the task is actually over.
+        # Docked can also mean an in-progress wash/dry cycle, so rely on the
+        # derived task_status instead of duplicating that interpretation here.
         activity = changes.get("activity")
-        if activity in ("idle", "docked", "error"):
+        task_status = changes.get("task_status")
+        should_clear_targets = (
+            activity in ("idle", "error") and state.activity not in ("idle", "error")
+        ) or (
+            activity == "docked"
+            and task_status == "Completed"
+            and state.task_status != "Completed"
+        )
+        if should_clear_targets:
             if state.active_room_ids or state.active_zone_count:
                 changes["active_room_ids"] = []
                 changes["active_room_names"] = ""
@@ -335,6 +353,11 @@ def _process_play_pause(
 
         if mode_ctrl.HasField("select_rooms_clean"):
             room_ids = [r.id for r in mode_ctrl.select_rooms_clean.rooms]
+            if not room_ids:
+                _LOGGER.debug(
+                    "Ignoring START_SELECT_ROOMS_CLEAN without room IDs; preserving existing active targets."
+                )
+                return
             changes["active_room_ids"] = room_ids
             room_lookup = {
                 r["id"]: r.get("name", f"Room {r['id']}") for r in state.rooms
@@ -342,12 +365,16 @@ def _process_play_pause(
             names = [room_lookup.get(rid, f"Room {rid}") for rid in room_ids]
             changes["active_room_names"] = ", ".join(names)
             changes["active_zone_count"] = 0
+            changes["current_scene_id"] = 0
+            changes["current_scene_name"] = None
             _track_field(state, changes, "active_room_ids")
 
         elif mode_ctrl.HasField("select_zones_clean"):
             changes["active_zone_count"] = len(mode_ctrl.select_zones_clean.zones)
             changes["active_room_ids"] = []
             changes["active_room_names"] = ""
+            changes["current_scene_id"] = 0
+            changes["current_scene_name"] = None
             _track_field(state, changes, "active_room_ids")
 
         # Scene: intentionally skipped (already tracked via WorkStatus.current_scene)

--- a/custom_components/robovac_mqtt/api/parser.py
+++ b/custom_components/robovac_mqtt/api/parser.py
@@ -38,6 +38,7 @@ from ..proto.cloud.multi_maps_pb2 import MultiMapsManageResponse
 from ..proto.cloud.scene_pb2 import SceneResponse
 from ..proto.cloud.station_pb2 import StationResponse
 from ..proto.cloud.stream_pb2 import RoomParams
+from ..proto.cloud.undisturbed_pb2 import UndisturbedResponse
 from ..proto.cloud.unisetting_pb2 import UnisettingResponse
 from ..proto.cloud.universal_data_pb2 import UniversalDataResponse
 from ..proto.cloud.work_status_pb2 import WorkStatus
@@ -457,6 +458,21 @@ def _process_other_dps(
                 if settings.HasField("children_lock"):
                     changes["child_lock"] = settings.children_lock.value
                     _track_field(state, changes, "child_lock")
+
+            elif key == DPS_MAP["UNDISTURBED"]:
+                undisturbed = decode(UndisturbedResponse, value)
+                _LOGGER.debug("Decoded UndisturbedResponse: %s", undisturbed)
+                if undisturbed.HasField("undisturbed"):
+                    changes["dnd_enabled"] = undisturbed.undisturbed.sw.value
+                    if undisturbed.undisturbed.HasField("begin"):
+                        changes["dnd_start_hour"] = undisturbed.undisturbed.begin.hour
+                        changes["dnd_start_minute"] = (
+                            undisturbed.undisturbed.begin.minute
+                        )
+                    if undisturbed.undisturbed.HasField("end"):
+                        changes["dnd_end_hour"] = undisturbed.undisturbed.end.hour
+                        changes["dnd_end_minute"] = undisturbed.undisturbed.end.minute
+                    _track_field(state, changes, "do_not_disturb")
 
             elif key == DPS_ROBOT_TELEMETRY:
                 pos = _parse_robot_telemetry(value)

--- a/custom_components/robovac_mqtt/api/parser.py
+++ b/custom_components/robovac_mqtt/api/parser.py
@@ -54,7 +54,7 @@ def _decode_varint(data: bytes, pos: int) -> tuple[int, int]:
         b = data[pos]
         value |= (b & 0x7F) << shift
         pos += 1
-        if not (b & 0x80):
+        if not b & 0x80:
             return value, pos
         shift += 7
     return value, pos
@@ -446,10 +446,7 @@ def _process_other_dps(
                     _LOGGER.debug("DPS 172: None value (initial state)")
                 else:
                     _LOGGER.debug("Received MULTI_MAP_MANAGE (DPS 172): %.100s", value)
-                    map_result = _parse_multi_map_response(value)
-                    if map_result:
-                        changes.update(map_result)
-                        _track_field(state, changes, "map_image")
+                    _parse_multi_map_response(value)
 
             elif key == DPS_MAP["UNSETTING"]:
                 settings = decode(UnisettingResponse, value)

--- a/custom_components/robovac_mqtt/api/parser.py
+++ b/custom_components/robovac_mqtt/api/parser.py
@@ -95,8 +95,14 @@ def _parse_robot_telemetry(value: str) -> dict[str, Any] | None:
         field 4: uint32  map X coordinate
         field 5: uint32  map Y coordinate
         field 6: bytes   additional data (2 packed varints)
+
+    See docs/DPS_179_TELEMETRY.md for detailed format documentation.
     """
-    raw = base64.b64decode(value)
+    try:
+        raw = base64.b64decode(value)
+    except Exception:
+        _LOGGER.debug("Failed to decode DPS 179 base64: %.50s", value)
+        return None
     _length, pos = _decode_varint(raw, 0)
     outer = _decode_raw_varints(raw[pos:])
     sub_bytes = outer.get(2)

--- a/custom_components/robovac_mqtt/api/parser.py
+++ b/custom_components/robovac_mqtt/api/parser.py
@@ -5,7 +5,6 @@ import logging
 from dataclasses import replace
 from typing import Any
 
-from google.protobuf.internal.decoder import _DecodeVarint
 from google.protobuf.json_format import MessageToDict
 
 from ..const import (
@@ -47,6 +46,20 @@ from ..utils import decode, deduplicate_names
 _LOGGER = logging.getLogger(__name__)
 
 
+def _decode_varint(data: bytes, pos: int) -> tuple[int, int]:
+    """Decode a protobuf varint starting at *pos*. Returns (value, new_pos)."""
+    value = 0
+    shift = 0
+    while pos < len(data):
+        b = data[pos]
+        value |= (b & 0x7F) << shift
+        pos += 1
+        if not (b & 0x80):
+            return value, pos
+        shift += 7
+    return value, pos
+
+
 def _decode_raw_varints(data: bytes) -> dict[int, int | bytes]:
     """Decode raw protobuf fields from bytes (no schema needed).
 
@@ -56,13 +69,13 @@ def _decode_raw_varints(data: bytes) -> dict[int, int | bytes]:
     fields: dict[int, int | bytes] = {}
     i = 0
     while i < len(data):
-        tag, i = _DecodeVarint(data, i)
+        tag, i = _decode_varint(data, i)
         fn, wt = tag >> 3, tag & 7
         if wt == 0:  # varint
-            val, i = _DecodeVarint(data, i)
+            val, i = _decode_varint(data, i)
             fields[fn] = val
         elif wt == 2:  # length-delimited
-            blen, i = _DecodeVarint(data, i)
+            blen, i = _decode_varint(data, i)
             fields[fn] = data[i : i + blen]
             i += blen
         else:
@@ -83,7 +96,7 @@ def _parse_robot_telemetry(value: str) -> dict[str, Any] | None:
         field 6: bytes   additional data (2 packed varints)
     """
     raw = base64.b64decode(value)
-    _length, pos = _DecodeVarint(raw, 0)
+    _length, pos = _decode_varint(raw, 0)
     outer = _decode_raw_varints(raw[pos:])
     sub_bytes = outer.get(2)
     if not isinstance(sub_bytes, bytes):
@@ -460,16 +473,6 @@ def _process_other_dps(
                     changes["robot_position_x"] = raw_x
                     changes["robot_position_y"] = raw_y
                     _track_field(state, changes, "robot_position")
-
-                    # Capture dock reference when robot is docked
-                    cur_activity = changes.get("activity", state.activity)
-                    if cur_activity == "docked":
-                        changes["dock_ref_x"] = raw_x
-                        changes["dock_ref_y"] = raw_y
-
-                    # NOTE: relative position (robot_rel_x/y) is computed
-                    # by the coordinator using configurable scale + rotation.
-                    # Parser only extracts raw coordinates and dock reference.
 
             elif key in KNOWN_UNPROCESSED_DPS:
                 pass  # Acknowledged; value already in raw_dps

--- a/custom_components/robovac_mqtt/binary_sensor.py
+++ b/custom_components/robovac_mqtt/binary_sensor.py
@@ -85,9 +85,11 @@ class RoboVacBinarySensor(CoordinatorEntity[EufyCleanCoordinator], BinarySensorE
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
+        if not super().available:
+            return False
         if self._availability_fn is not None:
             return self._availability_fn(self.coordinator.data)
-        return super().available
+        return True
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/robovac_mqtt/binary_sensor.py
+++ b/custom_components/robovac_mqtt/binary_sensor.py
@@ -43,18 +43,6 @@ async def async_setup_entry(
             )
         )
 
-        # Child Lock (from DPS 176 UnisettingResponse, read-only)
-        entities.append(
-            RoboVacBinarySensor(
-                coordinator,
-                "child_lock",
-                "Child Lock",
-                lambda s: s.child_lock,
-                category=EntityCategory.DIAGNOSTIC,
-                availability_fn=lambda s: "child_lock" in s.received_fields,
-            )
-        )
-
     async_add_entities(entities)
 
 

--- a/custom_components/robovac_mqtt/binary_sensor.py
+++ b/custom_components/robovac_mqtt/binary_sensor.py
@@ -43,6 +43,17 @@ async def async_setup_entry(
             )
         )
 
+        # Child Lock (from DPS 176 UnisettingResponse, read-only)
+        entities.append(
+            RoboVacBinarySensor(
+                coordinator,
+                "child_lock",
+                "Child Lock",
+                lambda s: s.child_lock,
+                category=EntityCategory.DIAGNOSTIC,
+            )
+        )
+
     async_add_entities(entities)
 
 

--- a/custom_components/robovac_mqtt/binary_sensor.py
+++ b/custom_components/robovac_mqtt/binary_sensor.py
@@ -51,6 +51,7 @@ async def async_setup_entry(
                 "Child Lock",
                 lambda s: s.child_lock,
                 category=EntityCategory.DIAGNOSTIC,
+                availability_fn=lambda s: "child_lock" in s.received_fields,
             )
         )
 
@@ -68,16 +69,25 @@ class RoboVacBinarySensor(CoordinatorEntity[EufyCleanCoordinator], BinarySensorE
         value_fn: Callable[[VacuumState], bool],
         device_class: BinarySensorDeviceClass | None = None,
         category: EntityCategory | None = EntityCategory.DIAGNOSTIC,
+        availability_fn: Callable[[VacuumState], bool] | None = None,
     ) -> None:
         """Initialize the binary sensor."""
         super().__init__(coordinator)
         self._value_fn = value_fn
+        self._availability_fn = availability_fn
         self._attr_unique_id = f"{coordinator.device_id}_{id_suffix}"
         self._attr_has_entity_name = True
         self._attr_name = name_suffix
         self._attr_device_info = coordinator.device_info
         self._attr_device_class = device_class
         self._attr_entity_category = category
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        if self._availability_fn is not None:
+            return self._availability_fn(self.coordinator.data)
+        return super().available
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/robovac_mqtt/const.py
+++ b/custom_components/robovac_mqtt/const.py
@@ -520,8 +520,34 @@ DPS_MAP = {
     "MAP_STREAM": "166",
     "UNSETTING": "176",
     "MAP_EDIT_REQUEST": "170",
+    "MULTI_MAP_MANAGE": "172",
     "MAP_MANAGE": "169",
 }
+
+# DPS keys that are known but intentionally not parsed.
+# Values are already stored in raw_dps for diagnostics.
+KNOWN_UNPROCESSED_DPS: frozenset[str] = frozenset({
+    DPS_MAP["DIRECTION"],        # 155 - RemoteCtrl echo
+    DPS_MAP["MULTI_MAP_SW"],     # 156 - multi-map toggle (also in DPS 176)
+    DPS_MAP["MAP_EDIT"],         # 164 - MapEditResponse ack
+    DPS_MAP["MAP_STREAM"],       # 166 - debug/metadata on T2351 (map data is local P2P only)
+    # Note: DPS 169 (MAP_MANAGE) is now parsed as DeviceInfo
+    DPS_MAP["MAP_EDIT_REQUEST"], # 170 - MapEditRequest echo
+    # Unknown DPS keys observed in the wild:
+    "150",  # Unknown, value: None
+    "151",  # Unknown, value: True
+    "157",  # Unknown protobuf, small config
+    "159",  # Unknown, value: True
+    "161",  # Unknown, likely volume (value: 80)
+    "162",  # Unknown protobuf, timing config
+    "171",  # Unknown, value: None
+    "174",  # Unknown, value: None
+    "175",  # Unknown, value: None
+    "178",  # Unknown protobuf, timestamp/event log
+})
+
+# DPS 179 key (no named entry in DPS_MAP — undocumented telemetry channel)
+DPS_ROBOT_TELEMETRY = "179"
 
 
 ACCESSORY_MAX_LIFE = {

--- a/custom_components/robovac_mqtt/const.py
+++ b/custom_components/robovac_mqtt/const.py
@@ -526,25 +526,29 @@ DPS_MAP = {
 
 # DPS keys that are known but intentionally not parsed.
 # Values are already stored in raw_dps for diagnostics.
-KNOWN_UNPROCESSED_DPS: frozenset[str] = frozenset({
-    DPS_MAP["DIRECTION"],        # 155 - RemoteCtrl echo
-    DPS_MAP["MULTI_MAP_SW"],     # 156 - multi-map toggle (also in DPS 176)
-    DPS_MAP["MAP_EDIT"],         # 164 - MapEditResponse ack
-    DPS_MAP["MAP_STREAM"],       # 166 - debug/metadata on T2351 (map data is local P2P only)
-    # Note: DPS 169 (MAP_MANAGE) is now parsed as DeviceInfo
-    DPS_MAP["MAP_EDIT_REQUEST"], # 170 - MapEditRequest echo
-    # Unknown DPS keys observed in the wild:
-    "150",  # Unknown, value: None
-    "151",  # Unknown, value: True
-    "157",  # Unknown protobuf, small config
-    "159",  # Unknown, value: True
-    "161",  # Unknown, likely volume (value: 80)
-    "162",  # Unknown protobuf, timing config
-    "171",  # Unknown, value: None
-    "174",  # Unknown, value: None
-    "175",  # Unknown, value: None
-    "178",  # Unknown protobuf, timestamp/event log
-})
+KNOWN_UNPROCESSED_DPS: frozenset[str] = frozenset(
+    {
+        DPS_MAP["DIRECTION"],  # 155 - RemoteCtrl echo
+        DPS_MAP["MULTI_MAP_SW"],  # 156 - multi-map toggle (also in DPS 176)
+        DPS_MAP["MAP_EDIT"],  # 164 - MapEditResponse ack
+        DPS_MAP[
+            "MAP_STREAM"
+        ],  # 166 - debug/metadata on T2351 (map data is local P2P only)
+        # Note: DPS 169 (MAP_MANAGE) is now parsed as DeviceInfo
+        DPS_MAP["MAP_EDIT_REQUEST"],  # 170 - MapEditRequest echo
+        # Unknown DPS keys observed in the wild:
+        "150",  # Unknown, value: None
+        "151",  # Unknown, value: True
+        "157",  # Unknown protobuf, small config
+        "159",  # Unknown, value: True
+        "161",  # Unknown, likely volume (value: 80)
+        "162",  # Unknown protobuf, timing config
+        "171",  # Unknown, value: None
+        "174",  # Unknown, value: None
+        "175",  # Unknown, value: None
+        "178",  # Unknown protobuf, timestamp/event log
+    }
+)
 
 # DPS 179 key (no named entry in DPS_MAP — undocumented telemetry channel)
 DPS_ROBOT_TELEMETRY = "179"

--- a/custom_components/robovac_mqtt/const.py
+++ b/custom_components/robovac_mqtt/const.py
@@ -522,6 +522,7 @@ DPS_MAP = {
     "MAP_EDIT_REQUEST": "170",
     "MULTI_MAP_MANAGE": "172",
     "MAP_MANAGE": "169",
+    "UNDISTURBED": "157",
 }
 
 # DPS keys that are known but intentionally not parsed.
@@ -539,7 +540,6 @@ KNOWN_UNPROCESSED_DPS: frozenset[str] = frozenset(
         # Unknown DPS keys observed in the wild:
         "150",  # Unknown, value: None
         "151",  # Unknown, value: True
-        "157",  # Unknown protobuf, small config
         "159",  # Unknown, value: True
         "161",  # Unknown, likely volume (value: 80)
         "162",  # Unknown protobuf, timing config

--- a/custom_components/robovac_mqtt/coordinator.py
+++ b/custom_components/robovac_mqtt/coordinator.py
@@ -218,9 +218,7 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
         """Set active cleaning targets on state (called when HA sends commands)."""
         rooms = self.data.rooms
         if room_ids:
-            room_lookup = {
-                r["id"]: r.get("name", f"Room {r['id']}") for r in rooms
-            }
+            room_lookup = {r["id"]: r.get("name", f"Room {r['id']}") for r in rooms}
             names = [room_lookup.get(rid, f"Room {rid}") for rid in room_ids]
             new_state = replace(
                 self.data,

--- a/custom_components/robovac_mqtt/coordinator.py
+++ b/custom_components/robovac_mqtt/coordinator.py
@@ -229,6 +229,8 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
                 active_room_ids=room_ids,
                 active_room_names=", ".join(names),
                 active_zone_count=0,
+                current_scene_id=0,
+                current_scene_name=None,
                 received_fields=self.data.received_fields | {"active_room_ids"},
             )
         else:
@@ -237,8 +239,23 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
                 active_room_ids=[],
                 active_room_names="",
                 active_zone_count=zone_count,
+                current_scene_id=0,
+                current_scene_name=None,
                 received_fields=self.data.received_fields | {"active_room_ids"},
             )
+        self.async_set_updated_data(new_state)
+
+    @callback
+    def set_active_scene(self, scene_id: int, scene_name: str | None) -> None:
+        """Set the active cleaning scene on state."""
+        new_state = replace(
+            self.data,
+            current_scene_id=scene_id,
+            current_scene_name=scene_name,
+            active_room_ids=[],
+            active_room_names="",
+            active_zone_count=0,
+        )
         self.async_set_updated_data(new_state)
 
     async def async_send_command(self, command_dict: dict[str, Any]) -> None:

--- a/custom_components/robovac_mqtt/coordinator.py
+++ b/custom_components/robovac_mqtt/coordinator.py
@@ -6,7 +6,7 @@ from dataclasses import replace
 from typing import Any
 
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.storage import Store
@@ -62,7 +62,7 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device info."""
-        return DeviceInfo(
+        info = DeviceInfo(
             identifiers={(DOMAIN, self.device_id)},
             name=self.device_name,
             manufacturer="Eufy",
@@ -70,6 +70,10 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
             serial_number=self.serial_number,
             sw_version=self.firmware_version,
         )
+        # Add MAC address from DPS 169 DeviceInfo if available
+        if mac := self.data.device_mac:
+            info["connections"] = {(CONNECTION_NETWORK_MAC, mac)}
+        return info
 
     async def initialize(self) -> None:
         """Initialize connection to the device."""
@@ -204,6 +208,36 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
         if self._segment_update_cancel:
             self._segment_update_cancel()
             self._segment_update_cancel = None
+
+    @callback
+    def set_active_cleaning_targets(
+        self,
+        room_ids: list[int] | None = None,
+        zone_count: int = 0,
+    ) -> None:
+        """Set active cleaning targets on state (called when HA sends commands)."""
+        rooms = self.data.rooms
+        if room_ids:
+            room_lookup = {
+                r["id"]: r.get("name", f"Room {r['id']}") for r in rooms
+            }
+            names = [room_lookup.get(rid, f"Room {rid}") for rid in room_ids]
+            new_state = replace(
+                self.data,
+                active_room_ids=room_ids,
+                active_room_names=", ".join(names),
+                active_zone_count=0,
+                received_fields=self.data.received_fields | {"active_room_ids"},
+            )
+        else:
+            new_state = replace(
+                self.data,
+                active_room_ids=[],
+                active_room_names="",
+                active_zone_count=zone_count,
+                received_fields=self.data.received_fields | {"active_room_ids"},
+            )
+        self.async_set_updated_data(new_state)
 
     async def async_send_command(self, command_dict: dict[str, Any]) -> None:
         """Send command to device."""

--- a/custom_components/robovac_mqtt/coordinator.py
+++ b/custom_components/robovac_mqtt/coordinator.py
@@ -6,7 +6,11 @@ from dataclasses import replace
 from typing import Any
 
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
+from homeassistant.helpers.device_registry import (
+    CONNECTION_NETWORK_MAC,
+    DeviceInfo,
+    format_mac,
+)
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.storage import Store
@@ -72,7 +76,7 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
         )
         # Add MAC address from DPS 169 DeviceInfo if available
         if mac := self.data.device_mac:
-            info["connections"] = {(CONNECTION_NETWORK_MAC, mac)}
+            info["connections"] = {(CONNECTION_NETWORK_MAC, format_mac(mac))}
         return info
 
     async def initialize(self) -> None:

--- a/custom_components/robovac_mqtt/manifest.json
+++ b/custom_components/robovac_mqtt/manifest.json
@@ -1,16 +1,13 @@
 {
-    "domain": "robovac_mqtt",
-    "name": "Eufy Robovac MQTT",
-    "codeowners": [
-        "@jeppesens",
-        "@m11tch"
-    ],
-    "config_flow": true,
-    "dependencies": [],
-    "documentation": "https://github.com/jeppesens/eufy-clean",
-    "integration_type": "device",
-    "iot_class": "cloud_push",
-    "issue_tracker": "https://github.com/jeppesens/eufy-clean/issues",
-    "requirements": [],
-    "version": "1.8.2"
+  "domain": "robovac_mqtt",
+  "name": "Eufy Robovac MQTT",
+  "codeowners": ["@jeppesens", "@m11tch"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/jeppesens/eufy-clean",
+  "integration_type": "device",
+  "iot_class": "cloud_push",
+  "issue_tracker": "https://github.com/jeppesens/eufy-clean/issues",
+  "requirements": [],
+  "version": "1.9.0"
 }

--- a/custom_components/robovac_mqtt/models.py
+++ b/custom_components/robovac_mqtt/models.py
@@ -68,6 +68,11 @@ class VacuumState:
     current_scene_id: int = 0
     current_scene_name: str | None = None
 
+    # Active cleaning targets (from DPS 152 echo)
+    active_room_ids: list[int] = field(default_factory=list)
+    active_room_names: str = ""  # Comma-separated resolved names
+    active_zone_count: int = 0
+
     # Accessories
     accessories: AccessoryState = field(default_factory=AccessoryState)
 
@@ -81,6 +86,19 @@ class VacuumState:
     carpet_strategy: str = "Auto Raise"  # Clean carpet strategy from DPS 154
     corner_cleaning: str = "Normal"  # Mop corner cleaning from DPS 154
     smart_mode: bool = False  # Smart mode switch from DPS 154
+
+    # Device settings (from DPS 176 UnisettingResponse)
+    wifi_signal: float = -100.0  # AP signal strength in dBm (converted from 0-100%)
+    child_lock: bool = False     # Children lock switch
+
+    # Device network info (from DPS 169, DeviceInfo proto)
+    device_mac: str = ""   # Device MAC address
+    wifi_ssid: str = ""    # Connected WiFi network name
+    wifi_ip: str = ""      # Device IP address
+
+    # Robot telemetry (from DPS 179, no known proto definition)
+    robot_position_x: int = 0  # Raw map X coordinate (firmware-internal grid)
+    robot_position_y: int = 0  # Raw map Y coordinate (firmware-internal grid)
 
     # Raw data for fallback/diagnostics
     raw_dps: dict[str, Any] = field(default_factory=dict)

--- a/custom_components/robovac_mqtt/models.py
+++ b/custom_components/robovac_mqtt/models.py
@@ -90,6 +90,11 @@ class VacuumState:
     # Device settings (from DPS 176 UnisettingResponse)
     wifi_signal: float = -100.0  # AP signal strength in dBm (converted from 0-100%)
     child_lock: bool = False  # Children lock switch
+    dnd_enabled: bool = False  # Do Not Disturb switch
+    dnd_start_hour: int = 22  # Do Not Disturb start hour
+    dnd_start_minute: int = 0  # Do Not Disturb start minute
+    dnd_end_hour: int = 8  # Do Not Disturb end hour
+    dnd_end_minute: int = 0  # Do Not Disturb end minute
 
     # Device network info (from DPS 169, DeviceInfo proto)
     device_mac: str = ""  # Device MAC address

--- a/custom_components/robovac_mqtt/models.py
+++ b/custom_components/robovac_mqtt/models.py
@@ -89,12 +89,12 @@ class VacuumState:
 
     # Device settings (from DPS 176 UnisettingResponse)
     wifi_signal: float = -100.0  # AP signal strength in dBm (converted from 0-100%)
-    child_lock: bool = False     # Children lock switch
+    child_lock: bool = False  # Children lock switch
 
     # Device network info (from DPS 169, DeviceInfo proto)
-    device_mac: str = ""   # Device MAC address
-    wifi_ssid: str = ""    # Connected WiFi network name
-    wifi_ip: str = ""      # Device IP address
+    device_mac: str = ""  # Device MAC address
+    wifi_ssid: str = ""  # Connected WiFi network name
+    wifi_ip: str = ""  # Device IP address
 
     # Robot telemetry (from DPS 179, no known proto definition)
     robot_position_x: int = 0  # Raw map X coordinate (firmware-internal grid)

--- a/custom_components/robovac_mqtt/select.py
+++ b/custom_components/robovac_mqtt/select.py
@@ -293,6 +293,7 @@ class SceneSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
 
         command = build_command("scene_clean", scene_id=scene_id)
         await self.coordinator.async_send_command(command)
+        self.coordinator.set_active_scene(scene_id, scene.get("name"))
 
         self.async_write_ha_state()
 
@@ -344,6 +345,7 @@ class RoomSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
 
         command = build_command("room_clean", room_ids=[room_id], map_id=map_id)
         await self.coordinator.async_send_command(command)
+        self.coordinator.set_active_cleaning_targets(room_ids=[room_id])
 
         self.async_write_ha_state()
 

--- a/custom_components/robovac_mqtt/select.py
+++ b/custom_components/robovac_mqtt/select.py
@@ -253,7 +253,6 @@ class SceneSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
         self._attr_has_entity_name = True
         self._attr_name = "Scene"
         self._attr_icon = "mdi:play-circle-outline"
-        self._attr_entity_category = EntityCategory.CONFIG
 
         self._attr_device_info = coordinator.device_info
 
@@ -308,7 +307,6 @@ class RoomSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
         self._attr_has_entity_name = True
         self._attr_name = "Clean Room"
         self._attr_icon = "mdi:door-open"
-        self._attr_entity_category = EntityCategory.CONFIG
 
         self._attr_device_info = coordinator.device_info
 

--- a/custom_components/robovac_mqtt/sensor.py
+++ b/custom_components/robovac_mqtt/sensor.py
@@ -13,8 +13,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-    UnitOfLength,
     EntityCategory,
+    UnitOfLength,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -269,8 +269,7 @@ async def async_setup_entry(
                 unit=UnitOfLength.METERS,
                 icon="mdi:crosshairs-gps",
                 availability_fn=lambda s: (
-                    "robot_position" in s.received_fields
-                    and s.dock_ref_x is not None
+                    "robot_position" in s.received_fields and s.dock_ref_x is not None
                 ),
                 suggested_display_precision=2,
             )
@@ -286,8 +285,7 @@ async def async_setup_entry(
                 unit=UnitOfLength.METERS,
                 icon="mdi:crosshairs-gps",
                 availability_fn=lambda s: (
-                    "robot_position" in s.received_fields
-                    and s.dock_ref_y is not None
+                    "robot_position" in s.received_fields and s.dock_ref_y is not None
                 ),
                 suggested_display_precision=2,
             )

--- a/custom_components/robovac_mqtt/sensor.py
+++ b/custom_components/robovac_mqtt/sensor.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
-    UnitOfLength,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/custom_components/robovac_mqtt/sensor.py
+++ b/custom_components/robovac_mqtt/sensor.py
@@ -25,6 +25,28 @@ from .coordinator import EufyCleanCoordinator, VacuumState
 _LOGGER = logging.getLogger(__name__)
 
 
+def _active_rooms_value(state: VacuumState) -> str | None:
+    """Return a display label for the current active cleaning target."""
+    if state.active_room_names:
+        return state.active_room_names
+    if state.current_scene_name:
+        return state.current_scene_name
+    if state.active_zone_count:
+        suffix = "" if state.active_zone_count == 1 else "s"
+        return f"{state.active_zone_count} zone{suffix}"
+    return None
+
+
+def _active_rooms_available(state: VacuumState) -> bool:
+    """Return whether any active cleaning target is currently known."""
+    return bool(
+        state.active_room_ids
+        or state.current_scene_id
+        or state.current_scene_name
+        or state.active_zone_count
+    )
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -163,21 +185,23 @@ async def async_setup_entry(
             )
         )
 
-        # Active Rooms sensor — unavailable when not room-cleaning
+        # Active cleaning target sensor
         entities.append(
             RoboVacSensor(
                 coordinator,
-                "active_rooms",
-                "Active Rooms",
-                lambda s: s.active_room_names or None,
+                "active_cleaning_target",
+                "Active Cleaning Target",
+                _active_rooms_value,
                 device_class=None,
                 unit=None,
                 state_class=None,
                 icon="mdi:floor-plan",
                 category=EntityCategory.DIAGNOSTIC,
-                availability_fn=lambda s: bool(s.active_room_ids),
+                availability_fn=_active_rooms_available,
                 extra_state_attributes_fn=lambda s: {
                     "room_ids": s.active_room_ids,
+                    "scene_id": s.current_scene_id,
+                    "scene_name": s.current_scene_name,
                     "zone_count": s.active_zone_count,
                 },
             )

--- a/custom_components/robovac_mqtt/sensor.py
+++ b/custom_components/robovac_mqtt/sensor.py
@@ -10,7 +10,12 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, EntityCategory
+from homeassistant.const import (
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    UnitOfLength,
+    EntityCategory,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -159,6 +164,135 @@ async def async_setup_entry(
             )
         )
 
+        # Active Rooms sensor — unavailable when not room-cleaning
+        entities.append(
+            RoboVacSensor(
+                coordinator,
+                "active_rooms",
+                "Active Rooms",
+                lambda s: s.active_room_names or None,
+                device_class=None,
+                unit=None,
+                state_class=None,
+                icon="mdi:floor-plan",
+                category=EntityCategory.DIAGNOSTIC,
+                availability_fn=lambda s: bool(s.active_room_ids),
+                extra_state_attributes_fn=lambda s: {
+                    "room_ids": s.active_room_ids,
+                    "zone_count": s.active_zone_count,
+                },
+            )
+        )
+
+        # WiFi Signal Strength (from DPS 176 UnisettingResponse)
+        entities.append(
+            RoboVacSensor(
+                coordinator,
+                "wifi_signal",
+                "WiFi Signal Strength",
+                lambda s: s.wifi_signal,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                unit=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+                state_class=SensorStateClass.MEASUREMENT,
+                icon="mdi:wifi",
+                category=EntityCategory.DIAGNOSTIC,
+                availability_fn=lambda s: "wifi_signal" in s.received_fields,
+                enabled_default=False,
+            )
+        )
+
+        # WiFi SSID (from DPS 169 DeviceInfo)
+        entities.append(
+            RoboVacSensor(
+                coordinator,
+                "wifi_ssid",
+                "WiFi SSID",
+                lambda s: s.wifi_ssid or None,
+                icon="mdi:wifi",
+                category=EntityCategory.DIAGNOSTIC,
+                availability_fn=lambda s: "wifi_ssid" in s.received_fields,
+                enabled_default=False,
+            )
+        )
+
+        # WiFi IP Address (from DPS 169 DeviceInfo)
+        entities.append(
+            RoboVacSensor(
+                coordinator,
+                "wifi_ip",
+                "IP Address",
+                lambda s: s.wifi_ip or None,
+                icon="mdi:ip-network",
+                category=EntityCategory.DIAGNOSTIC,
+                availability_fn=lambda s: "wifi_ip" in s.received_fields,
+                enabled_default=False,
+            )
+        )
+
+        # Robot Position - raw (from DPS 179 telemetry, diagnostic)
+        entities.append(
+            RoboVacSensor(
+                coordinator,
+                "robot_position_x",
+                "Robot Position X (raw)",
+                lambda s: s.robot_position_x,
+                state_class=SensorStateClass.MEASUREMENT,
+                icon="mdi:crosshairs-gps",
+                category=EntityCategory.DIAGNOSTIC,
+                availability_fn=lambda s: "robot_position" in s.received_fields,
+                enabled_default=False,
+            )
+        )
+
+        entities.append(
+            RoboVacSensor(
+                coordinator,
+                "robot_position_y",
+                "Robot Position Y (raw)",
+                lambda s: s.robot_position_y,
+                state_class=SensorStateClass.MEASUREMENT,
+                icon="mdi:crosshairs-gps",
+                category=EntityCategory.DIAGNOSTIC,
+                availability_fn=lambda s: "robot_position" in s.received_fields,
+                enabled_default=False,
+            )
+        )
+
+        # Robot Position - relative to dock (meters)
+        entities.append(
+            RoboVacSensor(
+                coordinator,
+                "robot_distance_x",
+                "Robot Distance X",
+                lambda s: s.robot_rel_x,
+                state_class=SensorStateClass.MEASUREMENT,
+                unit=UnitOfLength.METERS,
+                icon="mdi:crosshairs-gps",
+                availability_fn=lambda s: (
+                    "robot_position" in s.received_fields
+                    and s.dock_ref_x is not None
+                ),
+                suggested_display_precision=2,
+            )
+        )
+
+        entities.append(
+            RoboVacSensor(
+                coordinator,
+                "robot_distance_y",
+                "Robot Distance Y",
+                lambda s: s.robot_rel_y,
+                state_class=SensorStateClass.MEASUREMENT,
+                unit=UnitOfLength.METERS,
+                icon="mdi:crosshairs-gps",
+                availability_fn=lambda s: (
+                    "robot_position" in s.received_fields
+                    and s.dock_ref_y is not None
+                ),
+                suggested_display_precision=2,
+            )
+        )
+
         # Accessory Sensors
         accessories = [
             ("filter_usage", "Filter Remaining", "mdi:air-filter"),
@@ -227,6 +361,8 @@ class RoboVacSensor(CoordinatorEntity[EufyCleanCoordinator], SensorEntity):
             Callable[[VacuumState], dict[str, Any]] | None
         ) = None,
         availability_fn: Callable[[VacuumState], bool] | None = None,
+        enabled_default: bool = True,
+        suggested_display_precision: int | None = None,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
@@ -241,6 +377,7 @@ class RoboVacSensor(CoordinatorEntity[EufyCleanCoordinator], SensorEntity):
         # Result: sensor.robovac_water_level (Safer, avoids collisions)
         self._attr_has_entity_name = True
         self._attr_name = name_suffix
+        self._attr_entity_registry_enabled_default = enabled_default
 
         self._attr_device_info = coordinator.device_info
 
@@ -250,6 +387,8 @@ class RoboVacSensor(CoordinatorEntity[EufyCleanCoordinator], SensorEntity):
         self._attr_entity_category = category
         if icon:
             self._attr_icon = icon
+        if suggested_display_precision is not None:
+            self._attr_suggested_display_precision = suggested_display_precision
 
     @property
     def available(self) -> bool:

--- a/custom_components/robovac_mqtt/sensor.py
+++ b/custom_components/robovac_mqtt/sensor.py
@@ -258,39 +258,6 @@ async def async_setup_entry(
             )
         )
 
-        # Robot Position - relative to dock (meters)
-        entities.append(
-            RoboVacSensor(
-                coordinator,
-                "robot_distance_x",
-                "Robot Distance X",
-                lambda s: s.robot_rel_x,
-                state_class=SensorStateClass.MEASUREMENT,
-                unit=UnitOfLength.METERS,
-                icon="mdi:crosshairs-gps",
-                availability_fn=lambda s: (
-                    "robot_position" in s.received_fields and s.dock_ref_x is not None
-                ),
-                suggested_display_precision=2,
-            )
-        )
-
-        entities.append(
-            RoboVacSensor(
-                coordinator,
-                "robot_distance_y",
-                "Robot Distance Y",
-                lambda s: s.robot_rel_y,
-                state_class=SensorStateClass.MEASUREMENT,
-                unit=UnitOfLength.METERS,
-                icon="mdi:crosshairs-gps",
-                availability_fn=lambda s: (
-                    "robot_position" in s.received_fields and s.dock_ref_y is not None
-                ),
-                suggested_display_precision=2,
-            )
-        )
-
         # Accessory Sensors
         accessories = [
             ("filter_usage", "Filter Remaining", "mdi:air-filter"),

--- a/custom_components/robovac_mqtt/switch.py
+++ b/custom_components/robovac_mqtt/switch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import logging
 from collections.abc import Callable
+from dataclasses import replace
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
@@ -57,6 +58,7 @@ async def async_setup_entry(
             )
         )
 
+        entities.append(ChildLockSwitchEntity(coordinator))
         entities.append(FindRobotSwitchEntity(coordinator))
 
     async_add_entities(entities)
@@ -167,3 +169,45 @@ class FindRobotSwitchEntity(CoordinatorEntity[EufyCleanCoordinator], SwitchEntit
         """Turn the switch off."""
         command = build_command("find_robot", active=False)
         await self.coordinator.async_send_command(command)
+
+
+class ChildLockSwitchEntity(CoordinatorEntity[EufyCleanCoordinator], SwitchEntity):
+    """Switch for the device child lock setting."""
+
+    def __init__(self, coordinator: EufyCleanCoordinator) -> None:
+        """Initialize the child lock switch."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.device_id}_child_lock"
+        self._attr_has_entity_name = True
+        self._attr_name = "Child Lock"
+        self._attr_icon = "mdi:lock-outline"
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if child lock is enabled."""
+        return self.coordinator.data.child_lock
+
+    @property
+    def available(self) -> bool:
+        """Return whether the entity is available."""
+        return (
+            super().available and "child_lock" in self.coordinator.data.received_fields
+        )
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable child lock."""
+        await self._set_state(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable child lock."""
+        await self._set_state(False)
+
+    async def _set_state(self, state: bool) -> None:
+        """Send child lock command and optimistically update state."""
+        command = build_command("set_child_lock", active=state)
+        await self.coordinator.async_send_command(command)
+        self.coordinator.async_set_updated_data(
+            replace(self.coordinator.data, child_lock=state)
+        )

--- a/custom_components/robovac_mqtt/switch.py
+++ b/custom_components/robovac_mqtt/switch.py
@@ -58,6 +58,7 @@ async def async_setup_entry(
             )
         )
 
+        entities.append(DoNotDisturbSwitchEntity(coordinator))
         entities.append(ChildLockSwitchEntity(coordinator))
         entities.append(FindRobotSwitchEntity(coordinator))
 
@@ -81,6 +82,18 @@ def set_wash_cfg(cfg: dict[str, Any], val: bool) -> None:
         cfg["wash"] = {"cfg": "STANDARD" if val else "CLOSE"}
     else:
         cfg["wash"]["cfg"] = "STANDARD" if val else "CLOSE"
+
+
+def _current_dnd_schedule(coordinator: EufyCleanCoordinator) -> dict[str, int | bool]:
+    """Return the current Do Not Disturb schedule from coordinator state."""
+    data = coordinator.data
+    return {
+        "active": data.dnd_enabled,
+        "begin_hour": data.dnd_start_hour,
+        "begin_minute": data.dnd_start_minute,
+        "end_hour": data.dnd_end_hour,
+        "end_minute": data.dnd_end_minute,
+    }
 
 
 class DockSwitchEntity(CoordinatorEntity[EufyCleanCoordinator], SwitchEntity):
@@ -210,4 +223,58 @@ class ChildLockSwitchEntity(CoordinatorEntity[EufyCleanCoordinator], SwitchEntit
         await self.coordinator.async_send_command(command)
         self.coordinator.async_set_updated_data(
             replace(self.coordinator.data, child_lock=state)
+        )
+
+
+class DoNotDisturbSwitchEntity(CoordinatorEntity[EufyCleanCoordinator], SwitchEntity):
+    """Switch for the Do Not Disturb schedule."""
+
+    def __init__(self, coordinator: EufyCleanCoordinator) -> None:
+        """Initialize the DND switch."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.device_id}_do_not_disturb"
+        self._attr_has_entity_name = True
+        self._attr_name = "Do Not Disturb"
+        self._attr_icon = "mdi:minus-circle-off-outline"
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if DND is enabled."""
+        return self.coordinator.data.dnd_enabled
+
+    @property
+    def available(self) -> bool:
+        """Return whether the entity is available."""
+        return (
+            super().available
+            and "do_not_disturb" in self.coordinator.data.received_fields
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        """Return the current DND schedule."""
+        data = self.coordinator.data
+        return {
+            "start_time": f"{data.dnd_start_hour:02d}:{data.dnd_start_minute:02d}",
+            "end_time": f"{data.dnd_end_hour:02d}:{data.dnd_end_minute:02d}",
+        }
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable Do Not Disturb."""
+        await self._set_state(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable Do Not Disturb."""
+        await self._set_state(False)
+
+    async def _set_state(self, state: bool) -> None:
+        """Send DND command and optimistically update state."""
+        schedule = _current_dnd_schedule(self.coordinator)
+        schedule["active"] = state
+        command = build_command("set_do_not_disturb", **schedule)
+        await self.coordinator.async_send_command(command)
+        self.coordinator.async_set_updated_data(
+            replace(self.coordinator.data, dnd_enabled=state)
         )

--- a/custom_components/robovac_mqtt/time.py
+++ b/custom_components/robovac_mqtt/time.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import time as dt_time
+
+from homeassistant.components.time import TimeEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .api.commands import build_command
+from .const import DOMAIN
+from .coordinator import EufyCleanCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up DND time entities."""
+    data = hass.data[DOMAIN][config_entry.entry_id]
+    coordinators: list[EufyCleanCoordinator] = data["coordinators"]
+
+    entities = []
+    for coordinator in coordinators:
+        entities.append(DoNotDisturbStartTimeEntity(coordinator))
+        entities.append(DoNotDisturbEndTimeEntity(coordinator))
+
+    async_add_entities(entities)
+
+
+class _DoNotDisturbTimeEntity(CoordinatorEntity[EufyCleanCoordinator], TimeEntity):
+    """Base class for Do Not Disturb time entities."""
+
+    _field_prefix: str
+
+    def __init__(
+        self,
+        coordinator: EufyCleanCoordinator,
+        unique_id_suffix: str,
+        name: str,
+        icon: str,
+    ) -> None:
+        """Initialize the DND time entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.device_id}_{unique_id_suffix}"
+        self._attr_has_entity_name = True
+        self._attr_name = name
+        self._attr_icon = icon
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    def available(self) -> bool:
+        """Return whether the entity is available."""
+        return (
+            super().available
+            and "do_not_disturb" in self.coordinator.data.received_fields
+        )
+
+    @property
+    def native_value(self) -> dt_time:
+        """Return the current DND time value."""
+        data = self.coordinator.data
+        hour = getattr(data, f"{self._field_prefix}_hour")
+        minute = getattr(data, f"{self._field_prefix}_minute")
+        return dt_time(hour=hour, minute=minute)
+
+    async def async_set_value(self, value: dt_time) -> None:
+        """Update the DND schedule time."""
+        data = self.coordinator.data
+        command = build_command(
+            "set_do_not_disturb",
+            active=data.dnd_enabled,
+            begin_hour=(
+                value.hour if self._field_prefix == "dnd_start" else data.dnd_start_hour
+            ),
+            begin_minute=(
+                value.minute
+                if self._field_prefix == "dnd_start"
+                else data.dnd_start_minute
+            ),
+            end_hour=(
+                value.hour if self._field_prefix == "dnd_end" else data.dnd_end_hour
+            ),
+            end_minute=(
+                value.minute if self._field_prefix == "dnd_end" else data.dnd_end_minute
+            ),
+        )
+        await self.coordinator.async_send_command(command)
+        self.coordinator.async_set_updated_data(
+            replace(
+                data,
+                **{
+                    f"{self._field_prefix}_hour": value.hour,
+                    f"{self._field_prefix}_minute": value.minute,
+                },
+            )
+        )
+
+
+class DoNotDisturbStartTimeEntity(_DoNotDisturbTimeEntity):
+    """Time entity for DND start time."""
+
+    _field_prefix = "dnd_start"
+
+    def __init__(self, coordinator: EufyCleanCoordinator) -> None:
+        """Initialize the start time entity."""
+        super().__init__(
+            coordinator,
+            "do_not_disturb_start",
+            "Do Not Disturb Start",
+            "mdi:clock-start",
+        )
+
+
+class DoNotDisturbEndTimeEntity(_DoNotDisturbTimeEntity):
+    """Time entity for DND end time."""
+
+    _field_prefix = "dnd_end"
+
+    def __init__(self, coordinator: EufyCleanCoordinator) -> None:
+        """Initialize the end time entity."""
+        super().__init__(
+            coordinator,
+            "do_not_disturb_end",
+            "Do Not Disturb End",
+            "mdi:clock-end",
+        )

--- a/custom_components/robovac_mqtt/vacuum.py
+++ b/custom_components/robovac_mqtt/vacuum.py
@@ -266,6 +266,7 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
             command_kwargs["mode"] = mode
 
         command = build_command("room_clean", **command_kwargs)
+        self.coordinator.set_active_cleaning_targets(room_ids=room_ids)
         await self.coordinator.async_send_command(command)
 
     async def _async_send_room_custom(
@@ -410,6 +411,8 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
             "error_message": data.error_message,
             "status_code": data.status_code,
             "work_mode": data.work_mode,
+            "active_room_ids": data.active_room_ids,
+            "active_zone_count": data.active_zone_count,
             "rooms": rooms,
             "segments": segments,
         }

--- a/custom_components/robovac_mqtt/vacuum.py
+++ b/custom_components/robovac_mqtt/vacuum.py
@@ -492,9 +492,19 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
         """Send a raw command to the vacuum."""
         if command == "scene_clean":
             if isinstance(params, dict) and "scene_id" in params:
-                await self.coordinator.async_send_command(
-                    build_command("scene_clean", scene_id=params["scene_id"])
+                scene_id = params["scene_id"]
+                scene_name = next(
+                    (
+                        scene.get("name")
+                        for scene in self.coordinator.data.scenes
+                        if scene["id"] == scene_id
+                    ),
+                    None,
                 )
+                await self.coordinator.async_send_command(
+                    build_command("scene_clean", scene_id=scene_id)
+                )
+                self.coordinator.set_active_scene(scene_id, scene_name)
             return
 
         if command == "room_clean" and isinstance(params, dict):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -265,3 +265,94 @@ def test_update_state_undisturbed():
     assert new_state.dnd_end_hour == 8
     assert new_state.dnd_end_minute == 0
     assert "do_not_disturb" in changes["received_fields"]
+
+
+def test_completed_docked_refresh_keeps_cleared_targets():
+    """Test repeated completed docked updates keep targets cleared."""
+    state = VacuumState(
+        activity="docked",
+        task_status="Completed",
+        active_room_ids=[],
+        active_room_names="",
+    )
+
+    dps = {DPS_MAP["WORK_STATUS"]: "ChADGgByAiIAegA="}
+    new_state, _ = update_state(state, dps)
+
+    assert new_state.activity == "docked"
+    assert new_state.task_status == "Completed"
+    assert new_state.active_room_ids == []
+    assert new_state.active_room_names == ""
+
+
+@patch("custom_components.robovac_mqtt.api.parser.decode")
+def test_mid_clean_washing_does_not_clear_active_targets(mock_decode):
+    """Test dock-side washing preserves the active room target."""
+    state = VacuumState(
+        activity="cleaning",
+        active_room_ids=[1],
+        active_room_names="Kitchen1",
+    )
+
+    mock_status = MagicMock()
+    mock_status.state = 5
+    mock_status.cleaning.state = 1
+    mock_status.go_wash.mode = 1
+    mock_status.mode.value = 1
+    mock_status.HasField.side_effect = lambda field: field in {
+        "mode",
+        "charging",
+        "cleaning",
+        "go_wash",
+        "station",
+    }
+    mock_status.station.HasField.return_value = True
+    mock_decode.return_value = mock_status
+
+    dps = {DPS_MAP["WORK_STATUS"]: "encoded"}
+    new_state, _ = update_state(state, dps)
+
+    assert new_state.activity == "docked"
+    assert new_state.task_status == "Washing Mop"
+    assert new_state.active_room_ids == [1]
+    assert new_state.active_room_names == "Kitchen1"
+
+
+@patch("custom_components.robovac_mqtt.api.parser.decode")
+def test_completed_docked_state_clears_active_targets(mock_decode):
+    """Test completed docked states clear the active room target."""
+    state = VacuumState(
+        activity="docked",
+        task_status="Washing Mop",
+        active_room_ids=[1],
+        active_room_names="Kitchen1",
+    )
+
+    mock_status = MagicMock()
+    mock_status.state = 3
+    mock_status.HasField.side_effect = lambda field: field in {"charging"}
+    mock_decode.return_value = mock_status
+
+    dps = {DPS_MAP["WORK_STATUS"]: "encoded"}
+    new_state, _ = update_state(state, dps)
+
+    assert new_state.activity == "docked"
+    assert new_state.task_status == "Completed"
+    assert new_state.active_room_ids == []
+    assert new_state.active_room_names == ""
+
+
+def test_empty_room_clean_echo_preserves_existing_active_rooms():
+    """Test empty room-clean echoes do not wipe optimistic target state."""
+    state = VacuumState(
+        active_room_ids=[1],
+        active_room_names="Kitchen1",
+        rooms=[{"id": 1, "name": "Kitchen1"}],
+    )
+
+    dps = {DPS_MAP["PLAY_PAUSE"]: "AggB"}
+    new_state, changes = update_state(state, dps)
+
+    assert new_state.active_room_ids == [1]
+    assert new_state.active_room_names == "Kitchen1"
+    assert "active_room_ids" not in changes

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,7 +18,11 @@ from custom_components.robovac_mqtt.api.parser import update_state
 from custom_components.robovac_mqtt.const import DPS_MAP, EUFY_CLEAN_CONTROL
 from custom_components.robovac_mqtt.models import VacuumState
 from custom_components.robovac_mqtt.proto.cloud.error_code_pb2 import ErrorCode
+from custom_components.robovac_mqtt.proto.cloud.unisetting_pb2 import (
+    UnisettingResponse,
+)
 from custom_components.robovac_mqtt.proto.cloud.work_status_pb2 import WorkStatus
+from custom_components.robovac_mqtt.utils import encode
 
 
 def test_update_state_battery():
@@ -319,6 +323,37 @@ def test_mid_clean_washing_does_not_clear_active_targets(mock_decode):
 
 
 @patch("custom_components.robovac_mqtt.api.parser.decode")
+def test_charging_paused_state_does_not_clear_active_targets(mock_decode):
+    """Test paused charging during wash preparation does not clear target."""
+    state = VacuumState(
+        activity="cleaning",
+        active_room_ids=[1],
+        active_room_names="Kitchen1",
+    )
+
+    mock_status = MagicMock()
+    mock_status.state = 3
+    mock_status.cleaning.state = 1
+    mock_status.HasField.side_effect = lambda field: field in {
+        "charging",
+        "cleaning",
+        "station",
+        "mode",
+    }
+    mock_status.mode.value = 1
+    mock_status.station.HasField.return_value = False
+    mock_decode.return_value = mock_status
+
+    dps = {DPS_MAP["WORK_STATUS"]: "encoded"}
+    new_state, _ = update_state(state, dps)
+
+    assert new_state.activity == "docked"
+    assert new_state.task_status == "Paused"
+    assert new_state.active_room_ids == [1]
+    assert new_state.active_room_names == "Kitchen1"
+
+
+@patch("custom_components.robovac_mqtt.api.parser.decode")
 def test_completed_docked_state_clears_active_targets(mock_decode):
     """Test completed docked states clear the active room target."""
     state = VacuumState(
@@ -369,7 +404,7 @@ def test_update_state_device_info_dps169():
         "hiLQgBEgQIAhADGgQIAhAPIgQIARABMgQIARADOgQIARABQgQIARADUgUIARCzJGoJVDI"
         "zNTFfb3Rh"
     }
-    new_state, changes = update_state(state, dps)
+    new_state, _ = update_state(state, dps)
     assert new_state.device_mac == "c0:8a:60:23:83:d9"
     assert new_state.wifi_ssid == "LuftHamnen"
     assert new_state.wifi_ip == "10.1.0.106"
@@ -379,18 +414,12 @@ def test_update_state_device_info_dps169():
 
 def test_update_state_wifi_signal_dps176():
     """Test parsing WiFi signal strength from DPS 176 (UnisettingResponse)."""
-    from custom_components.robovac_mqtt.proto.cloud.unisetting_pb2 import (
-        UnisettingResponse,
-    )
-    from custom_components.robovac_mqtt.utils import encode
-
     # Build a UnisettingResponse with ap_signal_strength=80 (i.e. -60 dBm)
-    settings = UnisettingResponse(ap_signal_strength=80)
     encoded = encode(UnisettingResponse, {"ap_signal_strength": 80})
 
     state = VacuumState()
     dps = {DPS_MAP["UNSETTING"]: encoded}
-    new_state, changes = update_state(state, dps)
+    new_state, _ = update_state(state, dps)
     assert new_state.wifi_signal == -60.0
     assert "wifi_signal" in new_state.received_fields
 
@@ -414,6 +443,6 @@ def test_known_unprocessed_dps_does_not_crash():
     state = VacuumState()
     # DPS 155 (DIRECTION), 156 (MULTI_MAP_SW), 161 (unknown) are in KNOWN_UNPROCESSED_DPS
     dps = {"155": None, "156": True, "161": 80}
-    new_state, changes = update_state(state, dps)
+    new_state, _ = update_state(state, dps)
     # Should not crash and state should be unchanged (except raw_dps)
     assert new_state.activity == "idle"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -356,3 +356,64 @@ def test_empty_room_clean_echo_preserves_existing_active_rooms():
     assert new_state.active_room_ids == [1]
     assert new_state.active_room_names == "Kitchen1"
     assert "active_room_ids" not in changes
+
+
+def test_update_state_device_info_dps169():
+    """Test parsing DPS 169 (DeviceInfo) for MAC, WiFi SSID, and WiFi IP."""
+    state = VacuumState()
+    # Real DPS 169 payload from a T2351 (X10 Pro Omni)
+    dps = {
+        DPS_MAP["MAP_MANAGE"]: "vgEKF2V1ZnkgQ2xlYW4gWDEwIFBybyBPbW5pGhFjMDo"
+        "4YTo2MDoyMzo4MzpkOSIGMy40Ljg1KAMyCkx1ZnRIYW1uZW46CjEwLjEuMC4xMDZCKD"
+        "A5OTM2ZDFkNjdhZjE2YWJlYzJiNDdhOTZjYmU5M2RiNTY4NmM2YzhaCgoGMS4yLjI3EA"
+        "hiLQgBEgQIAhADGgQIAhAPIgQIARABMgQIARADOgQIARABQgQIARADUgUIARCzJGoJVDI"
+        "zNTFfb3Rh"
+    }
+    new_state, changes = update_state(state, dps)
+    assert new_state.device_mac == "c0:8a:60:23:83:d9"
+    assert new_state.wifi_ssid == "LuftHamnen"
+    assert new_state.wifi_ip == "10.1.0.106"
+    assert "wifi_ssid" in new_state.received_fields
+    assert "wifi_ip" in new_state.received_fields
+
+
+def test_update_state_wifi_signal_dps176():
+    """Test parsing WiFi signal strength from DPS 176 (UnisettingResponse)."""
+    from custom_components.robovac_mqtt.proto.cloud.unisetting_pb2 import (
+        UnisettingResponse,
+    )
+    from custom_components.robovac_mqtt.utils import encode
+
+    # Build a UnisettingResponse with ap_signal_strength=80 (i.e. -60 dBm)
+    settings = UnisettingResponse(ap_signal_strength=80)
+    encoded = encode(UnisettingResponse, {"ap_signal_strength": 80})
+
+    state = VacuumState()
+    dps = {DPS_MAP["UNSETTING"]: encoded}
+    new_state, changes = update_state(state, dps)
+    assert new_state.wifi_signal == -60.0
+    assert "wifi_signal" in new_state.received_fields
+
+
+def test_update_state_robot_position_dps179():
+    """Test parsing robot position from DPS 179 telemetry."""
+    state = VacuumState()
+    # Real DPS 179 payload from active cleaning session
+    dps = {"179": "HBIaOhgIlrujzgYQYxhiIPx9KIcOMgbO3QKg6gI="}
+    new_state, changes = update_state(state, dps)
+    assert "robot_position_x" in changes
+    assert "robot_position_y" in changes
+    # Raw unsigned varint values from undocumented telemetry format
+    assert isinstance(new_state.robot_position_x, int)
+    assert isinstance(new_state.robot_position_y, int)
+    assert "robot_position" in new_state.received_fields
+
+
+def test_known_unprocessed_dps_does_not_crash():
+    """Test that known-but-unprocessed DPS keys are handled gracefully."""
+    state = VacuumState()
+    # DPS 155 (DIRECTION), 156 (MULTI_MAP_SW), 161 (unknown) are in KNOWN_UNPROCESSED_DPS
+    dps = {"155": None, "156": True, "161": 80}
+    new_state, changes = update_state(state, dps)
+    # Should not crash and state should be unchanged (except raw_dps)
+    assert new_state.activity == "idle"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,6 +11,7 @@ from custom_components.robovac_mqtt.api.commands import (
     build_set_clean_speed_command,
     build_set_cleaning_intensity_command,
     build_set_cleaning_mode_command,
+    build_set_undisturbed_command,
     build_set_water_level_command,
 )
 from custom_components.robovac_mqtt.api.parser import update_state
@@ -243,3 +244,24 @@ def test_update_state_find_robot():
     dps = {DPS_MAP["FIND_ROBOT"]: "false"}
     new_state, changes = update_state(state, dps)
     assert new_state.find_robot is False
+
+
+def test_build_set_undisturbed_command():
+    """Test building a Do Not Disturb command."""
+    cmd = build_set_undisturbed_command(True, 22, 0, 8, 0)
+    assert DPS_MAP["UNDISTURBED"] in cmd
+
+
+def test_update_state_undisturbed():
+    """Test parsing Do Not Disturb state from DPS 157."""
+    state = VacuumState()
+    dps = {DPS_MAP["UNDISTURBED"]: "EAoAEgwKAggBEgIIFhoCCAg="}
+
+    new_state, changes = update_state(state, dps)
+
+    assert new_state.dnd_enabled is True
+    assert new_state.dnd_start_hour == 22
+    assert new_state.dnd_start_minute == 0
+    assert new_state.dnd_end_hour == 8
+    assert new_state.dnd_end_minute == 0
+    assert "do_not_disturb" in changes["received_fields"]

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -20,6 +20,7 @@ def mock_coordinator():
     coordinator.device_name = "Test Vac"
     coordinator.device_model = "T2118"
     coordinator.data = VacuumState()
+    coordinator.last_update_success = True
     return coordinator
 
 
@@ -62,3 +63,22 @@ def test_charging_sensor_default_false(mock_coordinator):
     entity.hass = MagicMock()
 
     assert entity.is_on is False
+
+
+def test_binary_sensor_availability_honors_coordinator_state(mock_coordinator):
+    """Test custom availability does not bypass coordinator availability."""
+    mock_coordinator.data.received_fields = {"child_lock"}
+
+    entity = RoboVacBinarySensor(
+        mock_coordinator,
+        "child_lock",
+        "Child Lock",
+        lambda s: s.child_lock,
+        availability_fn=lambda s: "child_lock" in s.received_fields,
+    )
+    entity.hass = MagicMock()
+
+    assert entity.available is True
+
+    mock_coordinator.last_update_success = False
+    assert entity.available is False

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,10 +2,14 @@
 
 from custom_components.robovac_mqtt.api.commands import (
     build_command,
+    build_set_child_lock_command,
     build_set_cleaning_intensity_command,
     build_set_cleaning_mode_command,
     build_set_water_level_command,
 )
+from custom_components.robovac_mqtt.const import DPS_MAP
+from custom_components.robovac_mqtt.proto.cloud.unisetting_pb2 import UnisettingRequest
+from custom_components.robovac_mqtt.utils import decode
 
 
 def test_set_cleaning_mode_invalid():
@@ -29,3 +33,12 @@ def test_set_cleaning_intensity_invalid():
 def test_build_command_unknown_returns_empty():
     """Test build_command with unknown command returns empty dict."""
     assert not build_command("nonexistent_command")
+
+
+def test_set_child_lock_command():
+    """Child lock command should encode a writable UnisettingRequest."""
+    result = build_set_child_lock_command(True)
+
+    assert DPS_MAP["UNSETTING"] in result
+    decoded = decode(UnisettingRequest, result[DPS_MAP["UNSETTING"]])
+    assert decoded.children_lock.value is True

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -30,6 +30,8 @@ def mock_coordinator():
     coordinator.device_name = "Test Device"
     coordinator.device_model = "T2118"
     coordinator.async_send_command = AsyncMock()
+    coordinator.set_active_scene = MagicMock()
+    coordinator.set_active_cleaning_targets = MagicMock()
     coordinator.last_update_success = True
     return coordinator
 
@@ -158,6 +160,7 @@ async def test_scene_select_entity(mock_coordinator):
 
         mock_build.assert_called_with("scene_clean", scene_id=2)
         mock_coordinator.async_send_command.assert_called_with({"cmd": "scene_cmd"})
+        mock_coordinator.set_active_scene.assert_called_with(2, "Scene 2")
 
 
 @pytest.mark.asyncio
@@ -184,6 +187,7 @@ async def test_room_select_entity(mock_coordinator):
 
         mock_build.assert_called_with("room_clean", room_ids=[10], map_id=5)
         mock_coordinator.async_send_command.assert_called_with({"cmd": "room_cmd"})
+        mock_coordinator.set_active_cleaning_targets.assert_called_with(room_ids=[10])
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -10,7 +10,11 @@ from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import PERCENTAGE, EntityCategory
 
 from custom_components.robovac_mqtt.models import VacuumState
-from custom_components.robovac_mqtt.sensor import RoboVacSensor
+from custom_components.robovac_mqtt.sensor import (
+    RoboVacSensor,
+    _active_rooms_available,
+    _active_rooms_value,
+)
 
 
 @pytest.fixture
@@ -120,3 +124,20 @@ def test_error_message_sensor(mock_coordinator):
     # Clear error
     mock_coordinator.data.error_message = ""
     assert entity.native_value == ""
+
+
+def test_active_rooms_uses_scene_name_when_room_ids_are_empty(mock_coordinator):
+    """Test active rooms sensor falls back to scene names."""
+    mock_coordinator.data.current_scene_id = 7
+    mock_coordinator.data.current_scene_name = "After Dinner"
+
+    assert _active_rooms_available(mock_coordinator.data) is True
+    assert _active_rooms_value(mock_coordinator.data) == "After Dinner"
+
+
+def test_active_rooms_uses_zone_count_when_present(mock_coordinator):
+    """Test active rooms sensor falls back to zone count."""
+    mock_coordinator.data.active_zone_count = 2
+
+    assert _active_rooms_available(mock_coordinator.data) is True
+    assert _active_rooms_value(mock_coordinator.data) == "2 zones"

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -12,6 +12,7 @@ from custom_components.robovac_mqtt.models import VacuumState
 from custom_components.robovac_mqtt.switch import (
     ChildLockSwitchEntity,
     DockSwitchEntity,
+    DoNotDisturbSwitchEntity,
     FindRobotSwitchEntity,
     set_collect_dust,
     set_wash_cfg,
@@ -106,6 +107,35 @@ def test_child_lock_switch_unavailable_without_field(mock_coordinator):
     entity = ChildLockSwitchEntity(mock_coordinator)
 
     assert entity.available is False
+
+
+async def test_do_not_disturb_switch_turn_on_off(hass: HomeAssistant, mock_coordinator):
+    """Test toggling the Do Not Disturb switch."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    mock_coordinator.data.received_fields = {"do_not_disturb"}
+    mock_coordinator.data.dnd_enabled = False
+    mock_coordinator.data.dnd_start_hour = 22
+    mock_coordinator.data.dnd_start_minute = 0
+    mock_coordinator.data.dnd_end_hour = 8
+    mock_coordinator.data.dnd_end_minute = 0
+
+    entity = DoNotDisturbSwitchEntity(mock_coordinator)
+    entity.hass = hass
+
+    assert entity.available is True
+    assert entity.is_on is False
+    assert entity.extra_state_attributes == {
+        "start_time": "22:00",
+        "end_time": "08:00",
+    }
+
+    await entity.async_turn_on()
+    sent_command = mock_coordinator.async_send_command.call_args_list[-1][0][0]
+    assert DPS_MAP["UNDISTURBED"] in sent_command
+    updated_state = mock_coordinator.async_set_updated_data.call_args_list[-1][0][0]
+    assert updated_state.dnd_enabled is True
 
 
 async def test_dock_switches(hass: HomeAssistant, mock_coordinator):

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -10,6 +10,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.robovac_mqtt.const import DOMAIN, DPS_MAP
 from custom_components.robovac_mqtt.models import VacuumState
 from custom_components.robovac_mqtt.switch import (
+    ChildLockSwitchEntity,
     DockSwitchEntity,
     FindRobotSwitchEntity,
     set_collect_dust,
@@ -28,7 +29,9 @@ def mock_coordinator() -> MagicMock:
     coordinator.device_model = "T2118"
     coordinator.data = VacuumState()
     coordinator.async_send_command = AsyncMock()
+    coordinator.async_set_updated_data = MagicMock()
     coordinator.device_info = {}
+    coordinator.last_update_success = True
     return coordinator
 
 
@@ -68,6 +71,41 @@ async def test_find_robot_turn_on_off(hass: HomeAssistant, mock_coordinator):
     mock_coordinator.async_send_command.assert_called_with(
         {DPS_MAP["FIND_ROBOT"]: False}
     )
+
+
+async def test_child_lock_switch_turn_on_off(hass: HomeAssistant, mock_coordinator):
+    """Test toggling the child lock switch."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    mock_coordinator.data.received_fields = {"child_lock"}
+    mock_coordinator.data.child_lock = False
+
+    entity = ChildLockSwitchEntity(mock_coordinator)
+    entity.hass = hass
+
+    assert entity.available is True
+    assert entity.is_on is False
+
+    await entity.async_turn_on()
+    mock_coordinator.async_send_command.assert_called()
+    sent_command = mock_coordinator.async_send_command.call_args_list[-1][0][0]
+    assert DPS_MAP["UNSETTING"] in sent_command
+    updated_state = mock_coordinator.async_set_updated_data.call_args_list[-1][0][0]
+    assert updated_state.child_lock is True
+
+    await entity.async_turn_off()
+    sent_command = mock_coordinator.async_send_command.call_args_list[-1][0][0]
+    assert DPS_MAP["UNSETTING"] in sent_command
+    updated_state = mock_coordinator.async_set_updated_data.call_args_list[-1][0][0]
+    assert updated_state.child_lock is False
+
+
+def test_child_lock_switch_unavailable_without_field(mock_coordinator):
+    """Test child lock switch is hidden until the device reports support."""
+    entity = ChildLockSwitchEntity(mock_coordinator)
+
+    assert entity.available is False
 
 
 async def test_dock_switches(hass: HomeAssistant, mock_coordinator):

--- a/tests/test_task_status_flapping.py
+++ b/tests/test_task_status_flapping.py
@@ -231,11 +231,13 @@ def test_mid_cleaning_with_paused_state():
     )
     assert state.dock_status == "Idle"
 
-    # Now robot should show Completed
+    # With the current device behavior, CHARGING + cleaning.PAUSED can still be
+    # a transitional mid-clean dock state even after the dock has just gone Idle.
+    # We should not treat that as completion until the robot stops reporting the
+    # paused cleaning field.
     state, _ = update_state(
         state, {DPS_MAP["WORK_STATUS"]: "EgoCCAEQAxoAMgIIAXICIgB6AA=="}
     )
-    # After washing is done (dock_status is Idle, not washing), it should be Completed
     assert (
-        state.task_status == "Completed"
-    ), "Should be 'Completed' when CHARGING and dock is NOT washing"
+        state.task_status == "Paused"
+    ), "Should remain 'Paused' when CHARGING still reports cleaning.PAUSED"

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,0 +1,95 @@
+"""Unit tests for Do Not Disturb time entities."""
+
+from datetime import time as dt_time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.robovac_mqtt.const import DOMAIN, DPS_MAP
+from custom_components.robovac_mqtt.models import VacuumState
+from custom_components.robovac_mqtt.time import (
+    DoNotDisturbEndTimeEntity,
+    DoNotDisturbStartTimeEntity,
+)
+
+
+@pytest.fixture
+def coordinator_fixture() -> MagicMock:
+    """Mock the coordinator."""
+    coordinator = MagicMock()
+    coordinator.device_id = "test_device"
+    coordinator.device_name = "Test Vac"
+    coordinator.device_model = "T2118"
+    coordinator.data = VacuumState()
+    coordinator.async_send_command = AsyncMock()
+    coordinator.async_set_updated_data = MagicMock()
+    coordinator.device_info = {}
+    coordinator.last_update_success = True
+    return coordinator
+
+
+async def test_do_not_disturb_start_time_entity(
+    hass: HomeAssistant, request: pytest.FixtureRequest
+):
+    """Test updating DND start time."""
+    coordinator = request.getfixturevalue("coordinator_fixture")
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    coordinator.data.received_fields = {"do_not_disturb"}
+    coordinator.data.dnd_enabled = True
+    coordinator.data.dnd_start_hour = 22
+    coordinator.data.dnd_start_minute = 0
+    coordinator.data.dnd_end_hour = 8
+    coordinator.data.dnd_end_minute = 0
+
+    entity = DoNotDisturbStartTimeEntity(coordinator)
+    entity.hass = hass
+    entity.platform = AsyncMock()
+    entity.platform.platform = Platform.TIME
+
+    assert entity.native_value == dt_time(22, 0)
+
+    await entity.async_set_value(dt_time(23, 30))
+    sent_command = coordinator.async_send_command.call_args_list[-1][0][0]
+    assert DPS_MAP["UNDISTURBED"] in sent_command
+    updated_state = coordinator.async_set_updated_data.call_args_list[-1][0][0]
+    assert updated_state.dnd_start_hour == 23
+    assert updated_state.dnd_start_minute == 30
+    assert updated_state.dnd_end_hour == 8
+    assert updated_state.dnd_end_minute == 0
+
+
+async def test_do_not_disturb_end_time_entity(
+    hass: HomeAssistant, request: pytest.FixtureRequest
+):
+    """Test updating DND end time."""
+    coordinator = request.getfixturevalue("coordinator_fixture")
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    coordinator.data.received_fields = {"do_not_disturb"}
+    coordinator.data.dnd_enabled = True
+    coordinator.data.dnd_start_hour = 22
+    coordinator.data.dnd_start_minute = 0
+    coordinator.data.dnd_end_hour = 8
+    coordinator.data.dnd_end_minute = 0
+
+    entity = DoNotDisturbEndTimeEntity(coordinator)
+    entity.hass = hass
+    entity.platform = AsyncMock()
+    entity.platform.platform = Platform.TIME
+
+    assert entity.native_value == dt_time(8, 0)
+
+    await entity.async_set_value(dt_time(7, 15))
+    sent_command = coordinator.async_send_command.call_args_list[-1][0][0]
+    assert DPS_MAP["UNDISTURBED"] in sent_command
+    updated_state = coordinator.async_set_updated_data.call_args_list[-1][0][0]
+    assert updated_state.dnd_end_hour == 7
+    assert updated_state.dnd_end_minute == 15
+    assert updated_state.dnd_start_hour == 22
+    assert updated_state.dnd_start_minute == 0

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -138,6 +138,8 @@ async def test_set_fan_speed(mock_coordinator, mock_config_entry):
 async def test_async_send_command_raw(mock_coordinator, mock_config_entry):
     """Test sending raw commands."""
     entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
+    mock_coordinator.set_active_scene = MagicMock()
+    mock_coordinator.data.scenes = [{"id": 5, "name": "Evening"}]
 
     with patch("custom_components.robovac_mqtt.vacuum.build_command") as mock_build:
         mock_build.return_value = {"cmd": "raw"}
@@ -145,6 +147,7 @@ async def test_async_send_command_raw(mock_coordinator, mock_config_entry):
         # Test scene_clean
         await entity.async_send_command("scene_clean", params={"scene_id": 5})
         mock_build.assert_called_with("scene_clean", scene_id=5)
+        mock_coordinator.set_active_scene.assert_called_with(5, "Evening")
 
         # Test room_clean
         mock_coordinator.data.map_id = 9


### PR DESCRIPTION
## Summary
- **WiFi SSID, WiFi IP, Device MAC** sensors from DPS 169 (DeviceInfo proto)
- **WiFi signal strength** sensor in dBm from DPS 176 (UnisettingResponse)
- **Active cleaning rooms/zones** sensor from DPS 152 (ModeCtrlRequest echo)
- **Robot raw X/Y position** sensors from DPS 179 telemetry
- **Child lock** binary sensor from DPS 176
- **MAC address** in HA device registry for network linking
- **KNOWN_UNPROCESSED_DPS** suppresses debug warnings for 15+ known-but-unused DPS keys
- **Active cleaning targets** in vacuum entity extra state attributes

## Test plan
- [x] Verify WiFi SSID/IP/MAC sensors populate after MQTT connect
- [x] Verify WiFi signal sensor shows dBm value (should be negative, e.g. -45)
- [ ] Verify child lock binary sensor reflects device state
- [ ] Start a room clean and verify active room names sensor updates
- [x] Verify robot position X/Y update during cleaning (DPS 179)
- [x] Verify device shows MAC in HA device registry
- [ ] Verify no unknown DPS debug warnings for keys in KNOWN_UNPROCESSED_DPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)