### PR TITLE
feat: fire raw DPS 179 telemetry on HA event bus

### DIFF
--- a/custom_components/robovac_mqtt/const.py
+++ b/custom_components/robovac_mqtt/const.py
@@ -9,6 +9,12 @@ DOMAIN: Final = "robovac_mqtt"
 VACS: Final = "vacs"
 DEVICES: Final = "devices"
 
+# Fired on the HA event bus whenever a raw DPS 179 (position/map) payload
+# arrives from the device. Allows external integrations to consume position
+# telemetry directly without depending on entity state propagation.
+# Event data: device_id, device_name, device_model, payload (raw base64 str).
+EVENT_DPS_179: Final = "robovac_mqtt_telemetry_179"
+
 # Eufy API URLs
 EUFY_API_BASE_URL: Final = "https://api.eufylife.com"
 EUFY_HOME_API_BASE_URL: Final = "https://home-api.eufylife.com"

--- a/custom_components/robovac_mqtt/coordinator.py
+++ b/custom_components/robovac_mqtt/coordinator.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .api.client import EufyCleanClient
 from .api.cloud import EufyLogin
 from .api.parser import update_state
-from .const import DOMAIN
+from .const import DOMAIN, EVENT_DPS_179
 from .models import VacuumState
 
 _LOGGER = logging.getLogger(__name__)
@@ -125,6 +125,26 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
                 payload_data = json.loads(payload_data)
 
             if dps := payload_data.get("data"):
+                # Fire raw DPS 179 onto the HA event bus before any parsing so
+                # external integrations can consume position telemetry directly.
+                raw_179 = dps.get("179")
+                if isinstance(raw_179, str):
+                    try:
+                        self.hass.bus.async_fire(
+                            EVENT_DPS_179,
+                            {
+                                "device_id": self.device_id,
+                                "device_name": self.device_name,
+                                "device_model": self.device_model,
+                                "payload": raw_179,
+                            },
+                        )
+                    except Exception:
+                        _LOGGER.exception(
+                            "Failed to fire DPS 179 event for %s",
+                            self.device_name,
+                        )
+
                 # Calculate new state based on connection
                 new_state, changes = update_state(self.data, dps)
 


### PR DESCRIPTION
## Summary

Fires raw DPS 179 (position/map) payloads onto the Home Assistant event bus
as `robovac_mqtt_telemetry_179` whenever they arrive over MQTT.

DPS 179 carries the vacuum's live position and map data. Currently the only
way for an external integration to consume this is to watch the entity state
of the sensor that robovac_mqtt publishes from it. That approach has two
problems:

- **Latency** — entity state propagation adds a round-trip through the HA
  state machine. For position tracking this introduces noticeable lag.
- **Fidelity** — if two DPS 179 payloads arrive close together, only the
  last entity state is visible. Intermediate updates are silently dropped.

Firing the raw payload on the event bus before any parsing solves both:
consumers see every update at the moment it arrives, with full fidelity.

## Changes

- `const.py` — adds `EVENT_DPS_179 = "robovac_mqtt_telemetry_179"` so consumers can import the event name rather than hardcoding a string
- `coordinator.py` — fires the event inside `_handle_mqtt_message` before state parsing, imports `EVENT_DPS_179` from const

## Event payload

```python
{
    "device_id":    str,   # deviceId from the Eufy API (serial number)
    "device_name":  str,   # human-readable device name
    "device_model": str,   # model string e.g. "T2351"
    "payload":      str,   # raw base64-encoded DPS 179 protobuf
}
```

## Notes

- Purely additive — no existing behaviour is changed
- The event fires before `update_state` so consumers see the same bytes the coordinator sees, with no transformation applied
- If firing the event raises an exception it is caught and logged; it does not interrupt normal coordinator processing
- Consumers are responsible for decoding the protobuf payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)