### PR TITLE
fix(cloud): fall back to AIOT data in findModel when V2 list is empty

### DIFF
--- a/custom_components/robovac_mqtt/api/cloud.py
+++ b/custom_components/robovac_mqtt/api/cloud.py
@@ -49,7 +49,7 @@ class EufyLogin:
         devices = await self.eufyApi.get_device_list()
         devices = [
             {
-                **self.findModel(device["device_sn"]),
+                **self.findModel(device["device_sn"], aiot_device=device),
                 "apiType": self.checkApiType(device.get("dps", {})),
                 "mqtt": True,
                 "dps": device.get("dps", {}),
@@ -71,7 +71,7 @@ class EufyLogin:
             return "novel"
         return "legacy"
 
-    def findModel(self, deviceId: str):
+    def findModel(self, deviceId: str, aiot_device: dict | None = None):
         device = next((d for d in self.eufy_api_devices if d["id"] == deviceId), None)
 
         if device:
@@ -84,6 +84,23 @@ class EufyLogin:
                 or device.get("name"),
                 "deviceModelName": device.get("product", {}).get("name"),
                 "invalid": False,
+            }
+
+        # Fallback: accounts where the V2 endpoint returns no metadata for a
+        # device (e.g. devices added through the modern Eufy Clean app rather
+        # than the legacy EufyHome app) still get a usable entry from the
+        # AIOT device-list response, which carries device_model and
+        # device_name directly.
+        if aiot_device:
+            model_code = (aiot_device.get("device_model") or "")[:5]
+            return {
+                "deviceId": deviceId,
+                "deviceModel": model_code,
+                "deviceName": aiot_device.get("alias_name")
+                or aiot_device.get("device_name")
+                or "Eufy Robovac",
+                "deviceModelName": None,
+                "invalid": not bool(model_code),
             }
 
         return {

--- a/custom_components/robovac_mqtt/manifest.json
+++ b/custom_components/robovac_mqtt/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/jeppesens/eufy-clean/issues",
   "requirements": [],
-  "version": "1.9.0"
+  "version": "1.9.1"
 }

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -107,3 +107,82 @@ def test_find_model_empty_product_code():
     assert result["deviceModel"] == "T2210"
     assert result["deviceName"] == "Kitchen Vacuum"
     assert result["invalid"] is False
+
+
+def test_find_model_aiot_fallback_when_v2_empty():
+    """When V2 device list is empty, fall back to AIOT data from get_device_list.
+
+    Reproduces the bug where accounts that only have devices registered through
+    the modern Eufy Clean app (not the legacy EufyHome app) get an empty V2
+    device list, causing every AIOT device to be marked invalid and filtered
+    out — leaving the integration with zero discovered vacuums.
+    """
+    login = _make_login(eufy_api_devices=[])
+
+    aiot_device = {
+        "device_sn": "ACN4A00F46300847",
+        "device_model": "T2081",
+        "device_name": "Robovac",
+        "alias_name": None,
+    }
+    result = login.findModel("ACN4A00F46300847", aiot_device=aiot_device)
+
+    assert result["deviceId"] == "ACN4A00F46300847"
+    assert result["deviceModel"] == "T2081"
+    assert result["deviceName"] == "Robovac"
+    assert result["invalid"] is False
+
+
+def test_find_model_aiot_fallback_prefers_alias_name():
+    """The AIOT fallback prefers alias_name (user-set) over device_name."""
+    login = _make_login(eufy_api_devices=[])
+
+    aiot_device = {
+        "device_sn": "DEV003",
+        "device_model": "T2080",
+        "device_name": "Robovac",
+        "alias_name": "Upstairs Vacuum",
+    }
+    result = login.findModel("DEV003", aiot_device=aiot_device)
+
+    assert result["deviceName"] == "Upstairs Vacuum"
+
+
+def test_find_model_aiot_fallback_invalid_without_model():
+    """When neither V2 nor AIOT supply a model code, the device stays invalid."""
+    login = _make_login(eufy_api_devices=[])
+
+    aiot_device = {
+        "device_sn": "DEV004",
+        "device_model": "",
+        "device_name": "Mystery Device",
+    }
+    result = login.findModel("DEV004", aiot_device=aiot_device)
+
+    assert result["deviceModel"] == ""
+    assert result["invalid"] is True
+
+
+def test_find_model_v2_takes_precedence_over_aiot():
+    """When V2 has the device, its richer metadata wins over the AIOT fallback."""
+    login = _make_login(
+        eufy_api_devices=[
+            {
+                "id": "DEV005",
+                "product": {"product_code": "T2261xx", "name": "X8 Pro"},
+                "alias_name": "From V2",
+                "device_model": "T2261",
+            }
+        ]
+    )
+
+    aiot_device = {
+        "device_sn": "DEV005",
+        "device_model": "T2081",
+        "device_name": "From AIOT",
+    }
+    result = login.findModel("DEV005", aiot_device=aiot_device)
+
+    assert result["deviceModel"] == "T2261"
+    assert result["deviceName"] == "From V2"
+    assert result["deviceModelName"] == "X8 Pro"


### PR DESCRIPTION
## Summary

Accounts that only have devices registered through the modern **Eufy Clean** app (not the legacy EufyHome app) get an empty response from the V2 device-list endpoint at `api.eufylife.com/v1/device/v2`. When `findModel()` cross-references `get_device_list()` (AIOT) against `get_cloud_device_list()` (V2) and finds no V2 entry, it returns `invalid: True`. Every AIOT device is then filtered out of `mqtt_devices`, leaving the integration with zero discovered vacuums and the warning:

```
WARNING (MainThread) [custom_components.robovac_mqtt] No Eufy Clean devices found or initialized.
```

The AIOT response from `devicerelation/get_device_list` already carries everything we need (`device_model`, `device_name`, `alias_name`). This PR threads that response into `findModel()` and uses it as a fallback when V2 has no match. V2 still wins when present, so existing accounts keep their richer product metadata (`deviceModelName` etc.).

## Reproduction

- **Device:** Eufy Robovac Omni S2 (model code `T2081`)
- **Account:** added via Eufy Clean app only — never paired through EufyHome
- **Result before fix:** Setup completes, `core.config_entries` shows `"vacs":{}`, no entities created, log warning fires.
- **Result after fix:** 48 entities discovered with live MQTT data — vacuum, sensors (battery, dock_status, cleaning_area, cleaning_time, consumables × 6), selects (suction_level, cleaning_mode, water_level, etc.), switches (auto_empty, auto_wash, child_lock, DND), and time entities for DND schedule. Verified against `aiot-mqtt-us.anker.com`.

## Diagnostic notes

The `vacs` field in the config entry stays `{}` after the fix — that field appears to be populated by a different code path (or is legacy) and didn't block functionality in our testing. Happy to fold a follow-up into this PR if the maintainers want it populated here.

## Tests

Added 4 cases to `tests/test_cloud.py`:

- `test_find_model_aiot_fallback_when_v2_empty` — the bug case
- `test_find_model_aiot_fallback_prefers_alias_name` — name precedence
- `test_find_model_aiot_fallback_invalid_without_model` — edge case
- `test_find_model_v2_takes_precedence_over_aiot` — backward compat

## Test plan

- [ ] `pytest tests/test_cloud.py -v` passes (CI)
- [ ] Existing `test_find_model_*` cases still pass (no regression in V2-present path)
- [ ] Manual: setup against Clean-app-only account discovers devices
- [ ] Manual: setup against EufyHome-account still uses V2 metadata (deviceModelName populated)