### PR TITLE
feat(select): add "Idle" sentinel option for Scene and Room selects

### DIFF
--- a/custom_components/robovac_mqtt/select.py
+++ b/custom_components/robovac_mqtt/select.py
@@ -26,6 +26,11 @@ from .coordinator import EufyCleanCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+# Sentinel option shown in Scene/Clean Room selects when nothing is actively
+# running. Avoids the default "Unknown" state in the more-info card and makes
+# the "no current selection" case explicit. Selecting it is a no-op.
+_IDLE_OPTION = "Idle"
+
 
 def _format_option_label(item: dict[str, Any], default_name: str) -> str:
     """Format a select option label as '<name> (ID: <id>)'."""
@@ -259,7 +264,9 @@ class SceneSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
     @property
     def options(self) -> list[str]:
         """Return available scenes."""
-        return [_format_option_label(s, "Scene") for s in self.coordinator.data.scenes]
+        return [_IDLE_OPTION] + [
+            _format_option_label(s, "Scene") for s in self.coordinator.data.scenes
+        ]
 
     @property
     def current_option(self) -> str | None:
@@ -274,10 +281,13 @@ class SceneSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
             if self.coordinator.data.current_scene_name:
                 return f"{self.coordinator.data.current_scene_name} (ID: {current_id})"
 
-        return None
+        return _IDLE_OPTION
 
     async def async_select_option(self, option: str) -> None:
         """Trigger the selected scene."""
+        if option == _IDLE_OPTION:
+            return
+
         scenes = self.coordinator.data.scenes
         scene = next(
             (s for s in scenes if _format_option_label(s, "Scene") == option),
@@ -313,15 +323,20 @@ class RoomSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
     @property
     def options(self) -> list[str]:
         """Return available rooms."""
-        return [_format_option_label(r, "Room") for r in self.coordinator.data.rooms]
+        return [_IDLE_OPTION] + [
+            _format_option_label(r, "Room") for r in self.coordinator.data.rooms
+        ]
 
     @property
     def current_option(self) -> str | None:
         """Room selection is an action trigger."""
-        return None
+        return _IDLE_OPTION
 
     async def async_select_option(self, option: str) -> None:
         """Trigger cleaning of the selected room."""
+        if option == _IDLE_OPTION:
+            return
+
         rooms = self.coordinator.data.rooms
         room = next(
             (r for r in rooms if _format_option_label(r, "Room") == option),

--- a/custom_components/robovac_mqtt/select.py
+++ b/custom_components/robovac_mqtt/select.py
@@ -26,10 +26,40 @@ from .coordinator import EufyCleanCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-# Sentinel option shown in Scene/Clean Room selects when nothing is actively
-# running. Avoids the default "Unknown" state in the more-info card and makes
-# the "no current selection" case explicit. Selecting it is a no-op.
+# Status sentinels for SceneSelectEntity / RoomSelectEntity.
+#
+# The Scene and Room selects are momentary action triggers — they have no
+# inherent persistent state. Rather than fall back to "Unknown" (which HA
+# renders for ``state == None``) we surface the vacuum's current activity as
+# the select's ``current_option``. This is honest: when the device reports
+# ``docked``/``charging``/``idle`` the select shows "Idle", and when the
+# device is busy via some other path (manual clean, schedule, app) the select
+# shows the actual activity ("Cleaning", "Returning", etc.) instead of
+# misleadingly claiming "Idle".
+#
+# Selecting any of these sentinels is a no-op — they are not actionable.
 _IDLE_OPTION = "Idle"
+_ACTIVITY_LABELS: dict[str, str] = {
+    "docked": _IDLE_OPTION,
+    "charging": _IDLE_OPTION,
+    "idle": _IDLE_OPTION,
+    "cleaning": "Cleaning",
+    "returning": "Returning",
+    "paused": "Paused",
+    "error": "Error",
+}
+# Distinct labels in display order. "Idle" first; the rest reflect real
+# transient states the vacuum can be in. Used to populate the ``options``
+# list for SceneSelectEntity and RoomSelectEntity so that ``current_option``
+# is always a valid member of ``options``.
+_STATUS_OPTIONS: list[str] = list(dict.fromkeys(_ACTIVITY_LABELS.values()))
+
+
+def _activity_label(activity: str | None) -> str | None:
+    """Map a raw coordinator activity to a select sentinel option, if known."""
+    if activity is None:
+        return None
+    return _ACTIVITY_LABELS.get(activity)
 
 
 def _format_option_label(item: dict[str, Any], default_name: str) -> str:
@@ -263,14 +293,22 @@ class SceneSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
 
     @property
     def options(self) -> list[str]:
-        """Return available scenes."""
-        return [_IDLE_OPTION] + [
+        """Return status sentinels followed by available scenes."""
+        return _STATUS_OPTIONS + [
             _format_option_label(s, "Scene") for s in self.coordinator.data.scenes
         ]
 
     @property
     def current_option(self) -> str | None:
-        """Return the currently active scene."""
+        """Return the currently active scene, or a vacuum-activity sentinel.
+
+        When a scene is actively running we return the scene label. Otherwise
+        we mirror the coordinator's reported activity ("Idle" when docked or
+        idle, "Cleaning"/"Returning"/"Paused"/"Error" when busy via another
+        path). If the activity is unknown to us we fall through to ``None``
+        which renders as HA's standard "Unknown" — this should only occur
+        briefly on initial connect before the first DPS update arrives.
+        """
         current_id = self.coordinator.data.current_scene_id
         if current_id > 0:
             for scene in self.coordinator.data.scenes:
@@ -281,11 +319,13 @@ class SceneSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
             if self.coordinator.data.current_scene_name:
                 return f"{self.coordinator.data.current_scene_name} (ID: {current_id})"
 
-        return _IDLE_OPTION
+        return _activity_label(self.coordinator.data.activity)
 
     async def async_select_option(self, option: str) -> None:
         """Trigger the selected scene."""
-        if option == _IDLE_OPTION:
+        # Status sentinels (Idle, Cleaning, etc.) are display-only — selecting
+        # them must not dispatch any command.
+        if option in _STATUS_OPTIONS:
             return
 
         scenes = self.coordinator.data.scenes
@@ -322,19 +362,26 @@ class RoomSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
 
     @property
     def options(self) -> list[str]:
-        """Return available rooms."""
-        return [_IDLE_OPTION] + [
+        """Return status sentinels followed by available rooms."""
+        return _STATUS_OPTIONS + [
             _format_option_label(r, "Room") for r in self.coordinator.data.rooms
         ]
 
     @property
     def current_option(self) -> str | None:
-        """Room selection is an action trigger."""
-        return _IDLE_OPTION
+        """Mirror the vacuum's current activity.
+
+        Room selection is purely an action trigger — there's no equivalent of
+        ``current_scene_id`` for room cleans, so we never try to identify a
+        specific room. Instead we surface the vacuum activity so the dropdown
+        is honest about what the device is doing.
+        """
+        return _activity_label(self.coordinator.data.activity)
 
     async def async_select_option(self, option: str) -> None:
         """Trigger cleaning of the selected room."""
-        if option == _IDLE_OPTION:
+        # Status sentinels (Idle, Cleaning, etc.) are display-only.
+        if option in _STATUS_OPTIONS:
             return
 
         rooms = self.coordinator.data.rooms

--- a/tests/test_scene_state.py
+++ b/tests/test_scene_state.py
@@ -26,8 +26,10 @@ def test_scene_select_entity_mocked():
     entity = SceneSelectEntity(mock_coordinator)
     entity.hass = MagicMock()
 
-    # 2. Test Initial State (None)
-    assert entity.current_option is None
+    # 2. Test Initial State — VacuumState defaults activity to "idle" so the
+    # select reports "Idle" (the activity-mirrored sentinel) when no scene is
+    # active.
+    assert entity.current_option == "Idle"
 
     # 3. Simulate Scene Active (ID Match)
     mock_coordinator.data.current_scene_id = 8
@@ -42,11 +44,11 @@ def test_scene_select_entity_mocked():
     # Should use the reported name as fallback with ID
     assert entity.current_option == "New Scene (ID: 99)"
 
-    # 5. Simulate Scene Inactive (ID=0)
+    # 5. Simulate Scene Inactive (ID=0) — falls back to activity sentinel.
     mock_coordinator.data.current_scene_id = 0
     mock_coordinator.data.current_scene_name = None
 
-    assert entity.current_option is None
+    assert entity.current_option == "Idle"
 
 
 def test_scene_parsing_logic():

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -137,6 +137,9 @@ async def test_dock_select_entity_async(mock_coordinator):
         mock_coordinator.async_send_command.assert_called_with({"cmd": "test_cmd"})
 
 
+_STATUS_OPTIONS_FIXTURE = ["Idle", "Cleaning", "Returning", "Paused", "Error"]
+
+
 @pytest.mark.asyncio
 async def test_scene_select_entity(mock_coordinator):
     """Test SceneSelectEntity."""
@@ -150,7 +153,11 @@ async def test_scene_select_entity(mock_coordinator):
     entity.async_write_ha_state = MagicMock()
 
     assert entity.name == "Scene"
-    assert entity.options == ["Idle", "Scene 1 (ID: 1)", "Scene 2 (ID: 2)"]
+    assert (
+        entity.options
+        == _STATUS_OPTIONS_FIXTURE + ["Scene 1 (ID: 1)", "Scene 2 (ID: 2)"]
+    )
+    # VacuumState defaults activity to "idle" → renders as "Idle".
     assert entity.current_option == "Idle"
 
     with patch("custom_components.robovac_mqtt.select.build_command") as mock_build:
@@ -163,23 +170,78 @@ async def test_scene_select_entity(mock_coordinator):
         mock_coordinator.set_active_scene.assert_called_with(2, "Scene 2")
 
 
+@pytest.mark.parametrize(
+    "activity,expected",
+    [
+        ("idle", "Idle"),
+        ("docked", "Idle"),
+        ("charging", "Idle"),
+        ("cleaning", "Cleaning"),
+        ("returning", "Returning"),
+        ("paused", "Paused"),
+        ("error", "Error"),
+        ("totally_unknown_state", None),
+    ],
+)
+def test_scene_select_current_option_mirrors_activity(
+    mock_coordinator, activity, expected
+):
+    """When no scene is active, current_option mirrors the vacuum activity."""
+    mock_coordinator.data.scenes = [{"id": 1, "name": "Scene 1", "type": 1}]
+    mock_coordinator.data.current_scene_id = 0
+    mock_coordinator.data.activity = activity
+
+    entity = SceneSelectEntity(mock_coordinator)
+    assert entity.current_option == expected
+
+
+def test_room_select_current_option_mirrors_activity(mock_coordinator):
+    """RoomSelectEntity surfaces the vacuum activity as its current option."""
+    mock_coordinator.data.rooms = [{"id": 10, "name": "Kitchen"}]
+    mock_coordinator.data.activity = "cleaning"
+
+    entity = RoomSelectEntity(mock_coordinator)
+    assert entity.current_option == "Cleaning"
+
+
 @pytest.mark.asyncio
-async def test_scene_select_idle_option_is_noop(mock_coordinator):
-    """Selecting the Idle sentinel must not dispatch a command."""
-    mock_coordinator.data.scenes = [
-        {"id": 1, "name": "Scene 1", "type": 1},
-    ]
+@pytest.mark.parametrize(
+    "sentinel", ["Idle", "Cleaning", "Returning", "Paused", "Error"]
+)
+async def test_scene_select_status_sentinels_are_noop(mock_coordinator, sentinel):
+    """Selecting any status sentinel must not dispatch a command."""
+    mock_coordinator.data.scenes = [{"id": 1, "name": "Scene 1", "type": 1}]
 
     entity = SceneSelectEntity(mock_coordinator)
     entity.hass = MagicMock()
     entity.async_write_ha_state = MagicMock()
 
     with patch("custom_components.robovac_mqtt.select.build_command") as mock_build:
-        await entity.async_select_option("Idle")
+        await entity.async_select_option(sentinel)
 
     mock_build.assert_not_called()
     mock_coordinator.async_send_command.assert_not_called()
     mock_coordinator.set_active_scene.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "sentinel", ["Idle", "Cleaning", "Returning", "Paused", "Error"]
+)
+async def test_room_select_status_sentinels_are_noop(mock_coordinator, sentinel):
+    """Selecting any status sentinel on the Room select must be a no-op."""
+    mock_coordinator.data.rooms = [{"id": 10, "name": "Kitchen"}]
+
+    entity = RoomSelectEntity(mock_coordinator)
+    entity.hass = MagicMock()
+    entity.async_write_ha_state = MagicMock()
+
+    with patch("custom_components.robovac_mqtt.select.build_command") as mock_build:
+        await entity.async_select_option(sentinel)
+
+    mock_build.assert_not_called()
+    mock_coordinator.async_send_command.assert_not_called()
+    mock_coordinator.set_active_cleaning_targets.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -196,8 +258,12 @@ async def test_room_select_entity(mock_coordinator):
     entity.async_write_ha_state = MagicMock()
 
     assert entity.name == "Clean Room"
-    assert entity.options == ["Kitchen (ID: 10)", "Living Room (ID: 12)"]
-    assert entity.current_option is None
+    assert (
+        entity.options
+        == _STATUS_OPTIONS_FIXTURE + ["Kitchen (ID: 10)", "Living Room (ID: 12)"]
+    )
+    # VacuumState defaults activity to "idle" → renders as "Idle".
+    assert entity.current_option == "Idle"
 
     with patch("custom_components.robovac_mqtt.select.build_command") as mock_build:
         mock_build.return_value = {"cmd": "room_cmd"}

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -153,10 +153,10 @@ async def test_scene_select_entity(mock_coordinator):
     entity.async_write_ha_state = MagicMock()
 
     assert entity.name == "Scene"
-    assert (
-        entity.options
-        == _STATUS_OPTIONS_FIXTURE + ["Scene 1 (ID: 1)", "Scene 2 (ID: 2)"]
-    )
+    assert entity.options == _STATUS_OPTIONS_FIXTURE + [
+        "Scene 1 (ID: 1)",
+        "Scene 2 (ID: 2)",
+    ]
     # VacuumState defaults activity to "idle" → renders as "Idle".
     assert entity.current_option == "Idle"
 
@@ -258,10 +258,10 @@ async def test_room_select_entity(mock_coordinator):
     entity.async_write_ha_state = MagicMock()
 
     assert entity.name == "Clean Room"
-    assert (
-        entity.options
-        == _STATUS_OPTIONS_FIXTURE + ["Kitchen (ID: 10)", "Living Room (ID: 12)"]
-    )
+    assert entity.options == _STATUS_OPTIONS_FIXTURE + [
+        "Kitchen (ID: 10)",
+        "Living Room (ID: 12)",
+    ]
     # VacuumState defaults activity to "idle" → renders as "Idle".
     assert entity.current_option == "Idle"
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -150,8 +150,8 @@ async def test_scene_select_entity(mock_coordinator):
     entity.async_write_ha_state = MagicMock()
 
     assert entity.name == "Scene"
-    assert entity.options == ["Scene 1 (ID: 1)", "Scene 2 (ID: 2)"]
-    assert entity.current_option is None
+    assert entity.options == ["Idle", "Scene 1 (ID: 1)", "Scene 2 (ID: 2)"]
+    assert entity.current_option == "Idle"
 
     with patch("custom_components.robovac_mqtt.select.build_command") as mock_build:
         mock_build.return_value = {"cmd": "scene_cmd"}
@@ -161,6 +161,25 @@ async def test_scene_select_entity(mock_coordinator):
         mock_build.assert_called_with("scene_clean", scene_id=2)
         mock_coordinator.async_send_command.assert_called_with({"cmd": "scene_cmd"})
         mock_coordinator.set_active_scene.assert_called_with(2, "Scene 2")
+
+
+@pytest.mark.asyncio
+async def test_scene_select_idle_option_is_noop(mock_coordinator):
+    """Selecting the Idle sentinel must not dispatch a command."""
+    mock_coordinator.data.scenes = [
+        {"id": 1, "name": "Scene 1", "type": 1},
+    ]
+
+    entity = SceneSelectEntity(mock_coordinator)
+    entity.hass = MagicMock()
+    entity.async_write_ha_state = MagicMock()
+
+    with patch("custom_components.robovac_mqtt.select.build_command") as mock_build:
+        await entity.async_select_option("Idle")
+
+    mock_build.assert_not_called()
+    mock_coordinator.async_send_command.assert_not_called()
+    mock_coordinator.set_active_scene.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`SceneSelectEntity` and `RoomSelectEntity` are momentary action triggers — they have no real persistent state, so `current_option` returns `None` whenever the vacuum isn't actively running a scene/room clean.

In Home Assistant's auto-generated more-info / device card, a select with `state == None` renders as the literal string **"Unknown"**, which looks broken to end users:

> Scene: **Unknown**
> Clean Room: **Unknown**

This PR adds a sentinel `"Idle"` option to both selects:

- Prepended to `options`
- Returned from `current_option` when nothing is active
- No-op in `async_select_option` (does not dispatch a `scene_clean` / `room_clean` command)

After:
> Scene: **Idle**
> Clean Room: **Idle**

The active-scene path in `SceneSelectEntity.current_option` is unchanged — when the device reports an active scene, that label is still returned as before.

## Test plan

- [x] Updated existing `test_scene_select_entity` and `test_room_select_entity` to expect the new `Idle` option
- [x] Added `test_scene_select_idle_option_is_noop` verifying selecting `"Idle"` does not call `build_command`, `async_send_command`, or `set_active_scene`
- [x] Verified live on an Eufy Omni S2 (T2081) — both selects now show `Idle` at rest and correctly trigger scenes/rooms when a real option is chosen