### PR TITLE
Fix fan speed command sending string instead of int on DPS 158

### DIFF
--- a/custom_components/robovac_mqtt/api/commands.py
+++ b/custom_components/robovac_mqtt/api/commands.py
@@ -73,7 +73,7 @@ def build_set_clean_speed_command(clean_speed: str) -> dict[str, str]:
 
         if speed_lower in variants:
             idx = variants.index(speed_lower)
-            return {DPS_MAP["CLEAN_SPEED"]: str(idx) if isinstance(idx, int) else idx}
+            return {DPS_MAP["CLEAN_SPEED"]: idx}
 
     except ValueError:
         pass

--- a/custom_components/robovac_mqtt/api/commands.py
+++ b/custom_components/robovac_mqtt/api/commands.py
@@ -65,7 +65,7 @@ def _build_manual_cmd(cmd_name: str, active: bool = True) -> dict[str, str]:
     return {DPS_MAP["GO_HOME"]: value}
 
 
-def build_set_clean_speed_command(clean_speed: str) -> dict[str, str]:
+def build_set_clean_speed_command(clean_speed: str) -> dict[str, int]:
     """Build command to set fan speed."""
     try:
         speed_lower = clean_speed.lower()

--- a/custom_components/robovac_mqtt/manifest.json
+++ b/custom_components/robovac_mqtt/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/jeppesens/eufy-clean/issues",
   "requirements": [],
-  "version": "1.9.1"
+  "version": "1.9.2"
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -128,10 +128,10 @@ def test_build_set_clean_speed(mock_encode):
     """Test building set clean speed command."""
     # This one doesn't use encode, it sends raw index
     cmd = build_set_clean_speed_command("Standard")
-    assert cmd == {DPS_MAP["CLEAN_SPEED"]: "1"}
+    assert cmd == {DPS_MAP["CLEAN_SPEED"]: 1}
 
     cmd = build_command("set_fan_speed", fan_speed="Max")
-    assert cmd == {DPS_MAP["CLEAN_SPEED"]: "3"}
+    assert cmd == {DPS_MAP["CLEAN_SPEED"]: 3}
 
 
 @patch("custom_components.robovac_mqtt.api.commands.encode")
@@ -399,7 +399,7 @@ def test_update_state_device_info_dps169():
     # Real DPS 169 payload from a T2351 (X10 Pro Omni)
     dps = {
         DPS_MAP["MAP_MANAGE"]: "vgEKF2V1ZnkgQ2xlYW4gWDEwIFBybyBPbW5pGhFjMDo"
-        "4YTo2MDoyMzo4MzpkOSIGMy40Ljg1KAMyCkx1ZnRIYW1uZW46CjEwLjEuMC4xMDZCKD"
+        "4YTo2MDoyMzo4MzpkOSIGMy40Ljg1KAMyCkx1ZnRIYW1uZW06CjEwLjEuMC4xMDZCKD"
         "A5OTM2ZDFkNjdhZjE2YWJlYzJiNDdhOTZjYmU5M2RiNTY4NmM2YzhaCgoGMS4yLjI3EA"
         "hiLQgBEgQIAhADGgQIAhAPIgQIARABMgQIARADOgQIARABQgQIARADUgUIARCzJGoJVDI"
         "zNTFfb3Rh"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -399,7 +399,7 @@ def test_update_state_device_info_dps169():
     # Real DPS 169 payload from a T2351 (X10 Pro Omni)
     dps = {
         DPS_MAP["MAP_MANAGE"]: "vgEKF2V1ZnkgQ2xlYW4gWDEwIFBybyBPbW5pGhFjMDo"
-        "4YTo2MDoyMzo4MzpkOSIGMy40Ljg1KAMyCkx1ZnRIYW1uZW06CjEwLjEuMC4xMDZCKD"
+        "4YTo2MDoyMzo4MzpkOSIGMy40Ljg1KAMyCkx1ZnRIYW1uZW46CjEwLjEuMC4xMDZCKD"
         "A5OTM2ZDFkNjdhZjE2YWJlYzJiNDdhOTZjYmU5M2RiNTY4NmM2YzhaCgoGMS4yLjI3EA"
         "hiLQgBEgQIAhADGgQIAhAPIgQIARABMgQIARADOgQIARABQgQIARADUgUIARCzJGoJVDI"
         "zNTFfb3Rh"


### PR DESCRIPTION
NOTE: I only tested this on my own device, a Eufy C10 (T2292). If other models expect a string on DPS 158, this could be a regression.

Bug: Attempts to change suction fan speed result in the vacuum device making an acknowledgement sound, but no change in vacuum fan speed. build_set_clean_speed_command sends the speed index as a string (e.g. "2") instead of an integer (2). The vacuum acknowledges the command (plays the beep) but ignores it and doesn't change the fan speed because it expects an integer on DPS 158. The parser confirms this — _map_clean_speed handles both int and str because the device itself sends integers back. Fix: Remove the str() conversion. list.index() always returns an int, so the isinstance(idx, int) branch was always taken, always producing a string. Tested: Fan speed changes mid-clean now work correctly.