### PR TITLE
feat: add Eufy G50 (T2210) support — Tuya-style scalar DPS over Anker MQTT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,8 @@ custom_components/robovac_mqtt/
 ├── config_flow.py       # HA config UI: email/password login
 ├── const.py             # DPS_MAP, device models, enums, error codes (100+), API URLs
 ├── coordinator.py       # EufyCleanCoordinator: MQTT lifecycle, state mgmt, dock debounce
-├── models.py            # VacuumState, AccessoryState, CleaningPreferences dataclasses
+├── entity.py            # Capability gating: supported_api_types + filter_supported_entities
+├── models.py            # VacuumState, AccessoryState, CleaningPreferences dataclasses + track_received_field
 ├── utils.py             # decode()/encode_message() for protobuf serialization
 ├── vacuum.py            # StateVacuumEntity: start/stop/pause/return/locate/fan_speed
 ├── sensor.py            # Battery, error, task status, cleaning stats, consumables
@@ -51,7 +52,8 @@ custom_components/robovac_mqtt/
 │   ├── cloud.py         # EufyLogin: orchestrates login flow, retrieves MQTT creds
 │   ├── client.py        # EufyCleanClient: Paho MQTT wrapper, connect/send/receive
 │   ├── commands.py      # build_command() dispatcher + protobuf command builders
-│   └── parser.py        # update_state(): DPS -> VacuumState mapping (most complex file)
+│   ├── parser.py        # update_state(): DPS -> VacuumState mapping (most complex file)
+│   └── parser_scalar.py # process_scalar_dps(): scalar (Tuya-style) DPS parsing (e.g. G50)
 └── proto/cloud/         # 37 .proto files + generated *_pb2.py (pre-compiled, not built)
     ├── work_status.proto      # Vacuum state (mode, charging, cleaning, dock activity)
     ├── station.proto          # Dock status, water levels, auto-config
@@ -167,6 +169,11 @@ await self.coordinator.async_send_command(build_command("room_clean", room_ids=[
 # Availability - sensors check received_fields to avoid showing unsupported features
 availability_fn=lambda s: "dock_status" in s.received_fields
 ```
+
+Protocol gating: entities declare `supported_api_types = ("novel",)` / `("scalar",)`
+(class attr, or ctor kwarg on generic classes); platform setups pass candidates
+through `entity.filter_supported_entities()` so unsupported entities never reach
+the registry. Any non-scalar api type (legacy/unknown) is treated as novel.
 
 ## Startup Flow
 

--- a/custom_components/robovac_mqtt/api/cloud.py
+++ b/custom_components/robovac_mqtt/api/cloud.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from ..const import DPS_MAP
+from ..const import DPS_MAP, SCALAR_DPS
+from ..utils import is_protobuf_dps_value
 from .http import EufyHTTPClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,6 +68,22 @@ class EufyLogin:
 
     @staticmethod
     def checkApiType(dps: dict):
+        """Classify a device's DPS protocol from its initial state snapshot.
+
+        - "novel"  : Anker protobuf DPS (WORK_STATUS/CLEANING_PARAMETERS as base64)
+        - "scalar" : Tuya-style plain int/JSON DPS over MQTT (e.g. T2210/G50) —
+                     reuses the protobuf DPS *numbers* but with int values
+        - "legacy" : no protobuf DPS at all (pure Tuya cloud devices, PR #110)
+
+        Value-shape based: a key-presence check alone misclassifies scalar
+        devices (which carry protobuf DPS numbers with int values) as novel.
+        """
+        for key in (DPS_MAP["WORK_STATUS"], DPS_MAP["CLEANING_PARAMETERS"]):
+            val = dps.get(key)
+            if val is not None:
+                return "novel" if is_protobuf_dps_value(val) else "scalar"
+        if SCALAR_DPS["STATE"] in dps:
+            return "scalar"
         if any(k in dps for k in DPS_MAP.values()):
             return "novel"
         return "legacy"

--- a/custom_components/robovac_mqtt/api/commands.py
+++ b/custom_components/robovac_mqtt/api/commands.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, cast
 
@@ -11,6 +12,10 @@ from ..const import (
     EUFY_CLEAN_NOVEL_CLEAN_SPEED,
     MOP_CORNER_MAP,
     MOP_LEVEL_MAP,
+    SCALAR_CLEAN_PATTERN_NAMES,
+    SCALAR_DPS,
+    SCALAR_WORK_MODE_GO_HOME,
+    SCALAR_WORK_MODE_START,
 )
 from ..proto.cloud.clean_param_pb2 import CleanParam, CleanParamRequest, Fan
 from ..proto.cloud.consumable_pb2 import ConsumableRequest
@@ -290,6 +295,79 @@ def build_find_robot_command(active: bool) -> dict[str, Any]:
     return {DPS_MAP["FIND_ROBOT"]: active}
 
 
+# --- scalar command builders (e.g. T2210/G50) ----------------------
+# These DPS are scalar-protocol-only plain-int writes (no protobuf), so they are
+# model-agnostic. Verified live against a real G50 (see docs/g50_capture/FINDINGS.md).
+
+
+def build_set_boost_iq_command(active: bool) -> dict[str, Any]:
+    """scalar-protocol: toggle BoostIQ auto carpet boost (DPS 118)."""
+    return {SCALAR_DPS["BOOST_IQ"]: int(bool(active))}
+
+
+def build_set_cleaning_pattern_command(pattern: str) -> dict[str, Any]:
+    """scalar-protocol: set clean path pattern Arranged(1)/Random(2) (DPS 154)."""
+    reverse = {name: value for value, name in SCALAR_CLEAN_PATTERN_NAMES.items()}
+    return {SCALAR_DPS["CLEAN_PATTERN"]: reverse.get(pattern, 1)}
+
+
+def build_set_volume_command(volume_pct: int) -> dict[str, Any]:
+    """scalar-protocol: set voice volume (DPS 111, 0-10 = 0-100% in 10% steps)."""
+    step = max(0, min(10, round(volume_pct / 10)))
+    return {SCALAR_DPS["VOLUME"]: step}
+
+
+def build_set_auto_return_command(active: bool) -> dict[str, Any]:
+    """scalar-protocol: toggle "Auto-Return Cleaning" (DPS 135)."""
+    return {SCALAR_DPS["AUTO_RETURN"]: int(bool(active))}
+
+
+def build_set_activity_log_command(active: bool) -> dict[str, Any]:
+    """scalar-protocol: toggle activity-log upload (DPS 142)."""
+    return {SCALAR_DPS["ACTIVITY_LOG"]: int(bool(active))}
+
+
+def build_scalar_reset_accessory_command(accessory_key: str) -> dict[str, Any]:
+    """scalar-protocol: reset an accessory's life counter to 0 (DPS 150 JSON).
+
+    accessory_key is the DPS 150 field, e.g. "sensors", "dust_filter",
+    "side_brush", "roller_brush". Captured from the app's /req.
+    """
+    if not accessory_key:
+        return {}
+    return {SCALAR_DPS["ACCESSORIES"]: json.dumps({accessory_key: 0})}
+
+
+def build_scalar_suction_command(fan_speed: str) -> dict[str, Any]:
+    """scalar-protocol: set suction by name (DPS 102, 0=Quiet..3=Max)."""
+    levels = [s.value for s in EUFY_CLEAN_NOVEL_CLEAN_SPEED[:4]]
+    if fan_speed not in levels:
+        return {}
+    return {SCALAR_DPS["SUCTION"]: levels.index(fan_speed)}
+
+
+def build_scalar_child_lock_command(active: bool) -> dict[str, Any]:
+    """scalar-protocol: toggle child lock (DPS 139)."""
+    return {SCALAR_DPS["CHILD_LOCK"]: int(bool(active))}
+
+
+def build_scalar_find_robot_command(active: bool) -> dict[str, Any]:
+    """scalar-protocol: find-robot start/stop (DPS 103)."""
+    return {SCALAR_DPS["FIND_ROBOT"]: int(bool(active))}
+
+
+def build_scalar_undisturbed_command(
+    active: bool, begin_hour: int, begin_minute: int, end_hour: int, end_minute: int
+) -> dict[str, Any]:
+    """scalar-protocol: set DND (DPS 107 JSON {en, start_t:"HHMM", end_t:"HHMM"})."""
+    payload = {
+        "en": bool(active),
+        "start_t": f"{begin_hour:02d}{begin_minute:02d}",
+        "end_t": f"{end_hour:02d}{end_minute:02d}",
+    }
+    return {SCALAR_DPS["DND"]: json.dumps(payload)}
+
+
 def build_set_child_lock_command(active: bool) -> dict[str, str]:
     """Build command to toggle the child lock setting."""
     value = encode(UnisettingRequest, {"children_lock": {"value": active}})
@@ -317,9 +395,51 @@ def build_set_undisturbed_command(
     return {DPS_MAP["UNDISTURBED"]: value}
 
 
-def build_command(command: str, **kwargs: Any) -> dict[str, Any]:
-    """Unified command builder."""
+def build_command(
+    command: str, api_type: str = "novel", **kwargs: Any
+) -> dict[str, Any]:
+    """Unified command builder.
+
+    *api_type* ("novel" | "scalar") lets shared commands branch to scalar
+    (Tuya-style int/JSON) writes for scalar-protocol devices (e.g. T2210/G50).
+    Callers that omit it get the default novel (protobuf) behaviour.
+    """
     cmd = command.lower()
+    is_scalar = api_type == "scalar"
+
+    if is_scalar:
+        # Movement, captured verbatim from the app's /req (see FINDINGS.md):
+        #   start/clean -> {"5": 1};  go home -> {"5": 3};
+        #   pause -> {"122": 1};  resume -> {"122": 0}.
+        # (DPS 2/101 — the Tuya-canonical movement DPs — are ACKed but ignored by
+        # the G50 firmware; the app drives DPS 5 + 122 instead.)
+        if cmd == "start_auto":
+            return {SCALAR_DPS["WORK_MODE"]: SCALAR_WORK_MODE_START}
+        if cmd in ("play", "resume"):
+            return {SCALAR_DPS["PAUSE"]: 2}
+        if cmd in ("pause", "stop"):
+            return {SCALAR_DPS["PAUSE"]: 1}
+        if cmd in ("return_to_base", "go_home"):
+            return {SCALAR_DPS["WORK_MODE"]: SCALAR_WORK_MODE_GO_HOME}
+        if cmd == "clean_spot":
+            _LOGGER.warning("Spot clean is not yet mapped for scalar devices.")
+            return {}
+        if cmd == "set_fan_speed":
+            return build_scalar_suction_command(kwargs.get("fan_speed", ""))
+        if cmd == "set_child_lock":
+            return build_scalar_child_lock_command(bool(kwargs.get("active", True)))
+        if cmd in ("locate", "find_robot"):
+            return build_scalar_find_robot_command(bool(kwargs.get("active", True)))
+        if cmd == "set_do_not_disturb":
+            return build_scalar_undisturbed_command(
+                bool(kwargs.get("active", True)),
+                int(kwargs.get("begin_hour", 22)),
+                int(kwargs.get("begin_minute", 0)),
+                int(kwargs.get("end_hour", 8)),
+                int(kwargs.get("end_minute", 0)),
+            )
+        if cmd == "reset_accessory":
+            return build_scalar_reset_accessory_command(kwargs.get("scalar_key", ""))
 
     # Mode Control
     if cmd == "start_auto":
@@ -391,5 +511,19 @@ def build_command(command: str, **kwargs: Any) -> dict[str, Any]:
             int(kwargs.get("end_hour", 8)),
             int(kwargs.get("end_minute", 0)),
         )
+
+    # scalar commands
+    if cmd == "set_boost_iq":
+        return build_set_boost_iq_command(bool(kwargs.get("active", True)))
+    if cmd == "set_cleaning_pattern":
+        return build_set_cleaning_pattern_command(kwargs.get("pattern", ""))
+    if cmd == "set_volume":
+        return build_set_volume_command(int(kwargs.get("volume", 0)))
+    if cmd == "set_auto_return":
+        return build_set_auto_return_command(bool(kwargs.get("active", True)))
+    if cmd == "set_activity_log":
+        return build_set_activity_log_command(bool(kwargs.get("active", True)))
+    if cmd == "detangle_brush":
+        return {SCALAR_DPS["DETANGLE"]: 1}
 
     return {}

--- a/custom_components/robovac_mqtt/api/parser.py
+++ b/custom_components/robovac_mqtt/api/parser.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import base64
-import json
 import logging
 from dataclasses import replace
 from typing import Any
@@ -21,9 +20,6 @@ from ..const import (
     EUFY_CLEAN_NOVEL_CLEAN_SPEED,
     FAN_SUCTION_NAMES,
     KNOWN_UNPROCESSED_DPS,
-    SCALAR_CLEAN_PATTERN_NAMES,
-    SCALAR_DPS,
-    SCALAR_STATE_NAMES,
     MOP_WATER_LEVEL_NAMES,
     TRIGGER_SOURCE_NAMES,
     WORK_MODE_NAMES,
@@ -31,7 +27,7 @@ from ..const import (
     MopWaterLevel,
     TriggerSource,
 )
-from ..models import AccessoryState, VacuumState
+from ..models import AccessoryState, VacuumState, track_received_field
 from ..proto.cloud.app_device_info_pb2 import DeviceInfo
 from ..proto.cloud.clean_param_pb2 import CleanParamRequest, CleanParamResponse
 from ..proto.cloud.clean_statistics_pb2 import CleanStatistics
@@ -47,6 +43,7 @@ from ..proto.cloud.unisetting_pb2 import UnisettingResponse
 from ..proto.cloud.universal_data_pb2 import UniversalDataResponse
 from ..proto.cloud.work_status_pb2 import WorkStatus
 from ..utils import decode, deduplicate_names
+from .parser_scalar import process_scalar_dps
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -122,20 +119,6 @@ def _parse_robot_telemetry(value: str) -> dict[str, Any] | None:
     return {"x": inner[4], "y": inner[5]}
 
 
-def _track_field(state: VacuumState, changes: dict[str, Any], field_name: str) -> None:
-    """Track that a field has been received from the device.
-
-    This is used by sensors to determine availability.
-    Only updates if the field isn't already tracked.
-    """
-    if field_name not in state.received_fields:
-        _LOGGER.debug("Tracking new field for availability: %s", field_name)
-        # Get current set from changes if already modified, else from state
-        current = changes.get("received_fields", state.received_fields).copy()
-        current.add(field_name)
-        changes["received_fields"] = current
-
-
 def update_state(
     state: VacuumState, dps: dict[str, Any]
 ) -> tuple[VacuumState, dict[str, Any]]:
@@ -158,7 +141,7 @@ def update_state(
     # EufyLogin.checkApiType and carried on state.api_type.
     if state.api_type == "scalar":
         # Plain int/JSON Tuya-style DPS (e.g. T2210/G50), no protobuf.
-        _process_scalar_dps(state, dps, changes)
+        process_scalar_dps(state, dps, changes)
     else:
         # Novel: Anker length-prefixed protobuf DPS (X-series; also the
         # default for "legacy"/"unknown", which have no parser of their own).
@@ -172,246 +155,6 @@ def update_state(
         _LOGGER.debug("Received fields now: %s", changes["received_fields"])
 
     return replace(state, **changes), changes
-
-
-# scalar-protocol (scalar/JSON protocol) DPS keys whose JSON values map onto accessory
-# usage counters. See docs/g50_capture/FINDINGS.md.
-_SCALAR_ACCESSORY_FIELDS = {
-    "dust_filter": "filter_usage",
-    "roller_brush": "main_brush_usage",
-    "side_brush": "side_brush_usage",
-    "sensors": "sensor_usage",
-}
-
-
-def _g_int(value: Any) -> int | None:
-    """Coerce a scalar DPS value to int, or None if not numeric."""
-    if isinstance(value, bool):
-        return int(value)
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str) and value.lstrip("-").isdigit():
-        return int(value)
-    return None
-
-
-def _process_scalar_dps(
-    state: VacuumState, dps: dict[str, Any], changes: dict[str, Any]
-) -> None:
-    """Process DPS for scalar/JSON devices (e.g. T2210/G50).
-
-    These devices send plain ints and JSON instead of the X-series protobuf
-    blobs, on a different set of DPS numbers, and emit NO WorkStatus (DPS 153).
-    Each DPS is handled independently so one bad value never aborts the batch.
-    """
-    for key, value in dps.items():
-        try:
-            if key == SCALAR_DPS["STATE"]:
-                code = _g_int(value)
-                if code is None:
-                    continue
-                changes["status_code"] = code
-                changes["activity"] = SCALAR_STATE_NAMES.get(code, "idle")
-                changes["charging"] = code == 5
-                changes["task_status"] = _map_scalar_task_status(code)
-
-            elif key == SCALAR_DPS["BATTERY"]:
-                level = _g_int(value)
-                if level is not None:
-                    changes["battery_level"] = level
-                    _track_field(state, changes, "battery_level")
-
-            elif key == SCALAR_DPS["SUCTION"]:
-                idx = _g_int(value)
-                if idx is not None and 0 <= idx < 4:
-                    changes["fan_speed"] = EUFY_CLEAN_NOVEL_CLEAN_SPEED[idx].value
-                    _track_field(state, changes, "fan_speed")
-
-            elif key == SCALAR_DPS["BOOST_IQ"]:
-                b = _g_int(value)
-                if b is not None:
-                    changes["boost_iq"] = bool(b)
-                    _track_field(state, changes, "boost_iq")
-
-            elif key == SCALAR_DPS["CLEAN_PATTERN"]:
-                p = _g_int(value)
-                if p is not None and p in SCALAR_CLEAN_PATTERN_NAMES:
-                    changes["cleaning_pattern"] = SCALAR_CLEAN_PATTERN_NAMES[p]
-                    _track_field(state, changes, "cleaning_pattern")
-
-            elif key == SCALAR_DPS["VOLUME"]:
-                v = _g_int(value)
-                if v is not None:
-                    changes["volume"] = max(0, min(100, v * 10))
-                    _track_field(state, changes, "volume")
-
-            elif key == SCALAR_DPS["CHILD_LOCK"]:
-                c = _g_int(value)
-                if c is not None:
-                    changes["child_lock"] = bool(c)
-                    _track_field(state, changes, "child_lock")
-
-            elif key == SCALAR_DPS["FIND_ROBOT"]:
-                f = _g_int(value)
-                if f is not None:
-                    changes["find_robot"] = bool(f)
-
-            elif key == SCALAR_DPS["DND"]:
-                _process_scalar_dnd(state, value, changes)
-
-            elif key in (SCALAR_DPS["ERROR_CODE"], SCALAR_DPS["ERROR_CODE_ALT"]):
-                code = _g_int(value)
-                if code:  # non-zero fault wins (106 and 177 are both candidates)
-                    changes["error_code"] = code
-                    changes["error_message"] = EUFY_CLEAN_ERROR_CODES.get(
-                        code, "Unknown Error"
-                    )
-                elif "error_code" not in changes:  # clear only if nothing set yet
-                    changes["error_code"] = 0
-                    changes["error_message"] = ""
-
-            elif key == SCALAR_DPS["AUTO_RETURN"]:
-                c = _g_int(value)
-                if c is not None:
-                    changes["auto_return"] = bool(c)
-                    _track_field(state, changes, "auto_return")
-
-            elif key == SCALAR_DPS["ACTIVITY_LOG"]:
-                a = _g_int(value)
-                if a is not None:
-                    changes["activity_log_upload"] = bool(a)
-                    _track_field(state, changes, "activity_log_upload")
-
-            elif key == SCALAR_DPS["SCHEDULE"]:
-                scheds = _parse_scalar_schedules(value)
-                if scheds is not None:
-                    changes["schedules"] = scheds
-                    _track_field(state, changes, "schedules")
-
-            elif key == SCALAR_DPS["CLEAN_TIME"]:
-                secs = _g_int(value)  # DPS 109 is already in seconds
-                if secs is not None:
-                    changes["cleaning_time"] = secs
-                    _track_field(state, changes, "cleaning_stats")
-
-            elif key == SCALAR_DPS["CLEAN_AREA"]:
-                area = _g_int(value)  # DPS 110 is in m²
-                if area is not None:
-                    changes["cleaning_area"] = area
-                    _track_field(state, changes, "cleaning_stats")
-
-            elif key == SCALAR_DPS["ACCESSORIES"]:
-                _process_scalar_accessories(state, value, changes)
-
-            else:
-                _LOGGER.debug("scalar-protocol unhandled DPS %s: %s", key, value)
-
-        except Exception as e:
-            _LOGGER.warning(
-                "Error parsing scalar-protocol DPS %s: %s", key, e, exc_info=True
-            )
-
-    # DPS 122 is a motion flag (1=stationary, 0=moving). A stationary robot that
-    # is otherwise mid-clean is paused — reconcile after the loop so it doesn't
-    # matter whether 122 or 15 was processed first.
-    pause_flag = dps.get(SCALAR_DPS["PAUSE"])
-    if pause_flag is not None:
-        activity = changes.get("activity", state.activity)
-        if _g_int(pause_flag) == 1 and activity == "cleaning":
-            changes["activity"] = "paused"
-            changes["task_status"] = "Paused"
-
-
-def _map_scalar_task_status(code: int) -> str:
-    """Map scalar-protocol state int (DPS 15) to a human task-status string."""
-    return {
-        0: "Standby",
-        1: "Standby",
-        2: "Cleaning",
-        4: "Returning",
-        5: "Charging",
-        6: "Docked",
-        7: "Paused",
-    }.get(code, "Standby")
-
-
-_SCALAR_SCHEDULE_DAYS = {
-    "1": "Mon",
-    "2": "Tue",
-    "3": "Wed",
-    "4": "Thu",
-    "5": "Fri",
-    "6": "Sat",
-    "7": "Sun",
-}
-
-
-def _parse_scalar_schedules(value: Any) -> list[dict[str, Any]] | None:
-    """Decode the DPS 151 schedule JSON into friendly read-only entries.
-
-    Raw entry: {"e":bool, "t":"HHMM", "r":"<day digits 1=Mon..7=Sun>",
-                "s":suction 0-3, "f":pattern 1/2, "id":int}.
-    """
-    data = value if isinstance(value, dict) else json.loads(value)
-    out: list[dict[str, Any]] = []
-    for e in data.get("l", []):
-        t = str(e.get("t", "")).zfill(4)
-        s = e.get("s")
-        f = e.get("f")
-        out.append(
-            {
-                "id": e.get("id"),
-                "enabled": bool(e.get("e")),
-                "time": f"{t[:2]}:{t[2:]}" if t.isdigit() and len(t) == 4 else t,
-                "days": ", ".join(
-                    _SCALAR_SCHEDULE_DAYS.get(d, d) for d in str(e.get("r", ""))
-                ),
-                "suction": (
-                    EUFY_CLEAN_NOVEL_CLEAN_SPEED[s].value
-                    if isinstance(s, int) and 0 <= s < 4
-                    else s
-                ),
-                "pattern": SCALAR_CLEAN_PATTERN_NAMES.get(f, f),
-            }
-        )
-    return out
-
-
-def _process_scalar_dnd(
-    state: VacuumState, value: Any, changes: dict[str, Any]
-) -> None:
-    """Parse scalar-protocol DND JSON: {"en":bool,"start_t":"HHMM","end_t":"HHMM"}."""
-    data = value if isinstance(value, dict) else json.loads(value)
-    if "en" in data:
-        changes["dnd_enabled"] = bool(data["en"])
-    start = str(data.get("start_t", "")).zfill(4)
-    end = str(data.get("end_t", "")).zfill(4)
-    if start.isdigit() and len(start) == 4:
-        changes["dnd_start_hour"] = int(start[:2])
-        changes["dnd_start_minute"] = int(start[2:])
-    if end.isdigit() and len(end) == 4:
-        changes["dnd_end_hour"] = int(end[:2])
-        changes["dnd_end_minute"] = int(end[2:])
-    _track_field(state, changes, "do_not_disturb")
-
-
-def _process_scalar_accessories(
-    state: VacuumState, value: Any, changes: dict[str, Any]
-) -> None:
-    """Parse scalar-protocol accessory usage-counter JSON (DPS 150) into AccessoryState.
-
-    Stores raw usage counters; conversion to % remaining happens in the sensor
-    layer (per-accessory max life). See docs/g50_capture/FINDINGS.md.
-    """
-    data = value if isinstance(value, dict) else json.loads(value)
-    accessory_changes = {
-        field: int(data[json_key])
-        for json_key, field in _SCALAR_ACCESSORY_FIELDS.items()
-        if json_key in data
-    }
-    if accessory_changes:
-        changes["accessories"] = replace(state.accessories, **accessory_changes)
-        _track_field(state, changes, "accessories")
 
 
 def _process_station_status(
@@ -428,11 +171,11 @@ def _process_station_status(
         new_dock_status = _map_dock_status(station)
         # Debouncing is handled in coordinator, not here
         changes["dock_status"] = new_dock_status
-        _track_field(state, changes, "dock_status")
+        track_received_field(state, changes, "dock_status")
 
         if station.HasField("clean_water"):
             changes["station_clean_water"] = station.clean_water.value
-            _track_field(state, changes, "station_clean_water")
+            track_received_field(state, changes, "station_clean_water")
 
         # Auto Empty Config
         if station.HasField("auto_cfg_status"):
@@ -488,7 +231,7 @@ def _process_work_status(
         if work_status.HasField("mode"):
             mode_val = work_status.mode.value
             changes["work_mode"] = WORK_MODE_NAMES.get(mode_val, "unknown")
-            _track_field(state, changes, "work_mode")
+            track_received_field(state, changes, "work_mode")
         elif state.work_mode == "unknown" and changes.get("activity") == "cleaning":
             # If we don't know the mode yet but we are cleaning, default to Auto
             changes["work_mode"] = "Auto"
@@ -624,7 +367,7 @@ def _process_play_pause(
             changes["active_zone_count"] = 0
             changes["current_scene_id"] = 0
             changes["current_scene_name"] = None
-            _track_field(state, changes, "active_room_ids")
+            track_received_field(state, changes, "active_room_ids")
 
         elif mode_ctrl.HasField("select_zones_clean"):
             changes["active_zone_count"] = len(mode_ctrl.select_zones_clean.zones)
@@ -632,7 +375,7 @@ def _process_play_pause(
             changes["active_room_names"] = ""
             changes["current_scene_id"] = 0
             changes["current_scene_name"] = None
-            _track_field(state, changes, "active_room_ids")
+            track_received_field(state, changes, "active_room_ids")
 
         # Scene: intentionally skipped (already tracked via WorkStatus.current_scene)
         # Control commands (pause/resume/stop): no Param oneof, naturally ignored
@@ -657,11 +400,11 @@ def _process_other_dps(
         try:
             if key == DPS_MAP["BATTERY_LEVEL"]:
                 changes["battery_level"] = int(value)
-                _track_field(state, changes, "battery_level")
+                track_received_field(state, changes, "battery_level")
 
             elif key == DPS_MAP["CLEAN_SPEED"]:
                 changes["fan_speed"] = _map_clean_speed(value)
-                _track_field(state, changes, "fan_speed")
+                track_received_field(state, changes, "fan_speed")
 
             elif key == DPS_MAP["ERROR_CODE"]:
                 error_proto = decode(ErrorCode, value)
@@ -680,7 +423,7 @@ def _process_other_dps(
             elif key == DPS_MAP["ACCESSORIES_STATUS"]:
                 _LOGGER.debug("Received ACCESSORIES_STATUS: %s", value)
                 changes["accessories"] = _parse_accessories(state.accessories, value)
-                _track_field(state, changes, "accessories")
+                track_received_field(state, changes, "accessories")
 
             elif key == DPS_MAP["CLEANING_STATISTICS"]:
                 stats = decode(CleanStatistics, value)
@@ -688,7 +431,7 @@ def _process_other_dps(
                 if stats.HasField("single"):
                     changes["cleaning_time"] = stats.single.clean_duration
                     changes["cleaning_area"] = stats.single.clean_area
-                    _track_field(state, changes, "cleaning_stats")
+                    track_received_field(state, changes, "cleaning_stats")
 
             elif key == DPS_MAP["SCENE_INFO"]:
                 _LOGGER.debug("Received SCENE_INFO: %s", value)
@@ -700,7 +443,7 @@ def _process_other_dps(
                 if map_info:
                     changes["map_id"] = map_info.get("map_id", 0)
                     changes["rooms"] = map_info.get("rooms", [])
-                    _track_field(state, changes, "map_id")
+                    track_received_field(state, changes, "map_id")
 
             elif key == DPS_MAP["CLEANING_PARAMETERS"]:
                 _LOGGER.debug("Received CLEANING_PARAMETERS: %s", value)
@@ -721,10 +464,10 @@ def _process_other_dps(
                     changes["device_mac"] = info.device_mac
                 if info.wifi_name:
                     changes["wifi_ssid"] = info.wifi_name
-                    _track_field(state, changes, "wifi_ssid")
+                    track_received_field(state, changes, "wifi_ssid")
                 if info.wifi_ip:
                     changes["wifi_ip"] = info.wifi_ip
-                    _track_field(state, changes, "wifi_ip")
+                    track_received_field(state, changes, "wifi_ip")
 
             elif key == DPS_MAP["MULTI_MAP_MANAGE"]:
                 if value is None:
@@ -738,10 +481,10 @@ def _process_other_dps(
                 _LOGGER.debug("Decoded UnisettingResponse: %s", settings)
                 # Device reports 0-100%, approximate to dBm for HA convention
                 changes["wifi_signal"] = (settings.ap_signal_strength / 2) - 100
-                _track_field(state, changes, "wifi_signal")
+                track_received_field(state, changes, "wifi_signal")
                 if settings.HasField("children_lock"):
                     changes["child_lock"] = settings.children_lock.value
-                    _track_field(state, changes, "child_lock")
+                    track_received_field(state, changes, "child_lock")
 
             elif key == DPS_MAP["UNDISTURBED"]:
                 undisturbed = decode(UndisturbedResponse, value)
@@ -756,7 +499,7 @@ def _process_other_dps(
                     if undisturbed.undisturbed.HasField("end"):
                         changes["dnd_end_hour"] = undisturbed.undisturbed.end.hour
                         changes["dnd_end_minute"] = undisturbed.undisturbed.end.minute
-                    _track_field(state, changes, "do_not_disturb")
+                    track_received_field(state, changes, "do_not_disturb")
 
             elif key == DPS_ROBOT_TELEMETRY:
                 pos = _parse_robot_telemetry(value)
@@ -769,7 +512,7 @@ def _process_other_dps(
                     raw_x, raw_y = pos["x"], pos["y"]
                     changes["robot_position_x"] = raw_x
                     changes["robot_position_y"] = raw_y
-                    _track_field(state, changes, "robot_position")
+                    track_received_field(state, changes, "robot_position")
 
             elif key in KNOWN_UNPROCESSED_DPS:
                 _LOGGER.debug(
@@ -1144,13 +887,13 @@ def _process_cleaning_parameters(
         changes["cleaning_mode"] = CLEANING_MODE_NAMES.get(
             CleaningMode(mode_val), "Vacuum"
         )
-        _track_field(state, changes, "cleaning_mode")
+        track_received_field(state, changes, "cleaning_mode")
 
     # Extract Fan Speed (available on newer devices in DPS 154)
     if clean_param.HasField("fan"):
         fan_val = clean_param.fan.suction
         changes["fan_speed"] = FAN_SUCTION_NAMES.get(fan_val, "Standard")
-        _track_field(state, changes, "fan_speed")
+        track_received_field(state, changes, "fan_speed")
         _LOGGER.debug(
             "DPS 154: Extracted fan speed %s (value: %s)", changes["fan_speed"], fan_val
         )
@@ -1161,7 +904,7 @@ def _process_cleaning_parameters(
         changes["mop_water_level"] = MOP_WATER_LEVEL_NAMES.get(
             MopWaterLevel(level_val), "Medium"
         )
-        _track_field(state, changes, "mop_water_level")
+        track_received_field(state, changes, "mop_water_level")
         _LOGGER.debug(
             "DPS 154: Extracted mop water level %s (value: %s)",
             changes["mop_water_level"],
@@ -1174,7 +917,7 @@ def _process_cleaning_parameters(
     if clean_param.HasField("mop_mode"):
         corner_val = clean_param.mop_mode.corner_clean
         changes["corner_cleaning"] = CORNER_CLEANING_NAMES.get(corner_val, "Normal")
-        _track_field(state, changes, "corner_cleaning")
+        track_received_field(state, changes, "corner_cleaning")
         _LOGGER.debug(
             "DPS 154: Extracted corner cleaning %s (value: %s)",
             changes["corner_cleaning"],
@@ -1187,7 +930,7 @@ def _process_cleaning_parameters(
         changes["cleaning_intensity"] = CLEANING_INTENSITY_NAMES.get(
             extent_val, "Normal"
         )
-        _track_field(state, changes, "cleaning_intensity")
+        track_received_field(state, changes, "cleaning_intensity")
         _LOGGER.debug(
             "DPS 154: Extracted cleaning intensity %s (value: %s)",
             changes["cleaning_intensity"],
@@ -1198,7 +941,7 @@ def _process_cleaning_parameters(
     if clean_param.HasField("clean_carpet"):
         carpet_val = clean_param.clean_carpet.strategy
         changes["carpet_strategy"] = CARPET_STRATEGY_NAMES.get(carpet_val, "Auto Raise")
-        _track_field(state, changes, "carpet_strategy")
+        track_received_field(state, changes, "carpet_strategy")
         _LOGGER.debug(
             "DPS 154: Extracted carpet strategy %s (value: %s)",
             changes["carpet_strategy"],
@@ -1208,7 +951,7 @@ def _process_cleaning_parameters(
     # Extract Smart Mode Switch
     if clean_param.HasField("smart_mode_sw"):
         changes["smart_mode"] = clean_param.smart_mode_sw.value
-        _track_field(state, changes, "smart_mode")
+        track_received_field(state, changes, "smart_mode")
         _LOGGER.debug("DPS 154: Extracted smart mode %s", changes["smart_mode"])
 
     if _LOGGER.isEnabledFor(logging.DEBUG):

--- a/custom_components/robovac_mqtt/api/parser.py
+++ b/custom_components/robovac_mqtt/api/parser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import json
 import logging
 from dataclasses import replace
 from typing import Any
@@ -20,6 +21,9 @@ from ..const import (
     EUFY_CLEAN_NOVEL_CLEAN_SPEED,
     FAN_SUCTION_NAMES,
     KNOWN_UNPROCESSED_DPS,
+    SCALAR_CLEAN_PATTERN_NAMES,
+    SCALAR_DPS,
+    SCALAR_STATE_NAMES,
     MOP_WATER_LEVEL_NAMES,
     TRIGGER_SOURCE_NAMES,
     WORK_MODE_NAMES,
@@ -150,17 +154,264 @@ def update_state(
     new_raw_dps.update(dps)
     changes["raw_dps"] = new_raw_dps
 
-    # Helper functions to process specific DPS groups
-    _process_station_status(state, dps, changes)
-    _process_work_status(state, dps, changes)
-    _process_play_pause(state, dps, changes)
-    _process_other_dps(state, dps, changes)
+    # Dispatch on the DPS protocol, classified cloud-side at init by
+    # EufyLogin.checkApiType and carried on state.api_type.
+    if state.api_type == "scalar":
+        # Plain int/JSON Tuya-style DPS (e.g. T2210/G50), no protobuf.
+        _process_scalar_dps(state, dps, changes)
+    else:
+        # Novel: Anker length-prefixed protobuf DPS (X-series; also the
+        # default for "legacy"/"unknown", which have no parser of their own).
+        _process_station_status(state, dps, changes)
+        _process_work_status(state, dps, changes)
+        _process_play_pause(state, dps, changes)
+        _process_other_dps(state, dps, changes)
 
     # Log received_fields for debugging sensor availability
     if "received_fields" in changes:
         _LOGGER.debug("Received fields now: %s", changes["received_fields"])
 
     return replace(state, **changes), changes
+
+
+# scalar-protocol (scalar/JSON protocol) DPS keys whose JSON values map onto accessory
+# usage counters. See docs/g50_capture/FINDINGS.md.
+_SCALAR_ACCESSORY_FIELDS = {
+    "dust_filter": "filter_usage",
+    "roller_brush": "main_brush_usage",
+    "side_brush": "side_brush_usage",
+    "sensors": "sensor_usage",
+}
+
+
+def _g_int(value: Any) -> int | None:
+    """Coerce a scalar DPS value to int, or None if not numeric."""
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.lstrip("-").isdigit():
+        return int(value)
+    return None
+
+
+def _process_scalar_dps(
+    state: VacuumState, dps: dict[str, Any], changes: dict[str, Any]
+) -> None:
+    """Process DPS for scalar/JSON devices (e.g. T2210/G50).
+
+    These devices send plain ints and JSON instead of the X-series protobuf
+    blobs, on a different set of DPS numbers, and emit NO WorkStatus (DPS 153).
+    Each DPS is handled independently so one bad value never aborts the batch.
+    """
+    for key, value in dps.items():
+        try:
+            if key == SCALAR_DPS["STATE"]:
+                code = _g_int(value)
+                if code is None:
+                    continue
+                changes["status_code"] = code
+                changes["activity"] = SCALAR_STATE_NAMES.get(code, "idle")
+                changes["charging"] = code == 5
+                changes["task_status"] = _map_scalar_task_status(code)
+
+            elif key == SCALAR_DPS["BATTERY"]:
+                level = _g_int(value)
+                if level is not None:
+                    changes["battery_level"] = level
+                    _track_field(state, changes, "battery_level")
+
+            elif key == SCALAR_DPS["SUCTION"]:
+                idx = _g_int(value)
+                if idx is not None and 0 <= idx < 4:
+                    changes["fan_speed"] = EUFY_CLEAN_NOVEL_CLEAN_SPEED[idx].value
+                    _track_field(state, changes, "fan_speed")
+
+            elif key == SCALAR_DPS["BOOST_IQ"]:
+                b = _g_int(value)
+                if b is not None:
+                    changes["boost_iq"] = bool(b)
+                    _track_field(state, changes, "boost_iq")
+
+            elif key == SCALAR_DPS["CLEAN_PATTERN"]:
+                p = _g_int(value)
+                if p is not None and p in SCALAR_CLEAN_PATTERN_NAMES:
+                    changes["cleaning_pattern"] = SCALAR_CLEAN_PATTERN_NAMES[p]
+                    _track_field(state, changes, "cleaning_pattern")
+
+            elif key == SCALAR_DPS["VOLUME"]:
+                v = _g_int(value)
+                if v is not None:
+                    changes["volume"] = max(0, min(100, v * 10))
+                    _track_field(state, changes, "volume")
+
+            elif key == SCALAR_DPS["CHILD_LOCK"]:
+                c = _g_int(value)
+                if c is not None:
+                    changes["child_lock"] = bool(c)
+                    _track_field(state, changes, "child_lock")
+
+            elif key == SCALAR_DPS["FIND_ROBOT"]:
+                f = _g_int(value)
+                if f is not None:
+                    changes["find_robot"] = bool(f)
+
+            elif key == SCALAR_DPS["DND"]:
+                _process_scalar_dnd(state, value, changes)
+
+            elif key in (SCALAR_DPS["ERROR_CODE"], SCALAR_DPS["ERROR_CODE_ALT"]):
+                code = _g_int(value)
+                if code:  # non-zero fault wins (106 and 177 are both candidates)
+                    changes["error_code"] = code
+                    changes["error_message"] = EUFY_CLEAN_ERROR_CODES.get(
+                        code, "Unknown Error"
+                    )
+                elif "error_code" not in changes:  # clear only if nothing set yet
+                    changes["error_code"] = 0
+                    changes["error_message"] = ""
+
+            elif key == SCALAR_DPS["AUTO_RETURN"]:
+                c = _g_int(value)
+                if c is not None:
+                    changes["auto_return"] = bool(c)
+                    _track_field(state, changes, "auto_return")
+
+            elif key == SCALAR_DPS["ACTIVITY_LOG"]:
+                a = _g_int(value)
+                if a is not None:
+                    changes["activity_log_upload"] = bool(a)
+                    _track_field(state, changes, "activity_log_upload")
+
+            elif key == SCALAR_DPS["SCHEDULE"]:
+                scheds = _parse_scalar_schedules(value)
+                if scheds is not None:
+                    changes["schedules"] = scheds
+                    _track_field(state, changes, "schedules")
+
+            elif key == SCALAR_DPS["CLEAN_TIME"]:
+                secs = _g_int(value)  # DPS 109 is already in seconds
+                if secs is not None:
+                    changes["cleaning_time"] = secs
+                    _track_field(state, changes, "cleaning_stats")
+
+            elif key == SCALAR_DPS["CLEAN_AREA"]:
+                area = _g_int(value)  # DPS 110 is in m²
+                if area is not None:
+                    changes["cleaning_area"] = area
+                    _track_field(state, changes, "cleaning_stats")
+
+            elif key == SCALAR_DPS["ACCESSORIES"]:
+                _process_scalar_accessories(state, value, changes)
+
+            else:
+                _LOGGER.debug("scalar-protocol unhandled DPS %s: %s", key, value)
+
+        except Exception as e:
+            _LOGGER.warning(
+                "Error parsing scalar-protocol DPS %s: %s", key, e, exc_info=True
+            )
+
+    # DPS 122 is a motion flag (1=stationary, 0=moving). A stationary robot that
+    # is otherwise mid-clean is paused — reconcile after the loop so it doesn't
+    # matter whether 122 or 15 was processed first.
+    pause_flag = dps.get(SCALAR_DPS["PAUSE"])
+    if pause_flag is not None:
+        activity = changes.get("activity", state.activity)
+        if _g_int(pause_flag) == 1 and activity == "cleaning":
+            changes["activity"] = "paused"
+            changes["task_status"] = "Paused"
+
+
+def _map_scalar_task_status(code: int) -> str:
+    """Map scalar-protocol state int (DPS 15) to a human task-status string."""
+    return {
+        0: "Standby",
+        1: "Standby",
+        2: "Cleaning",
+        4: "Returning",
+        5: "Charging",
+        6: "Docked",
+        7: "Paused",
+    }.get(code, "Standby")
+
+
+_SCALAR_SCHEDULE_DAYS = {
+    "1": "Mon",
+    "2": "Tue",
+    "3": "Wed",
+    "4": "Thu",
+    "5": "Fri",
+    "6": "Sat",
+    "7": "Sun",
+}
+
+
+def _parse_scalar_schedules(value: Any) -> list[dict[str, Any]] | None:
+    """Decode the DPS 151 schedule JSON into friendly read-only entries.
+
+    Raw entry: {"e":bool, "t":"HHMM", "r":"<day digits 1=Mon..7=Sun>",
+                "s":suction 0-3, "f":pattern 1/2, "id":int}.
+    """
+    data = value if isinstance(value, dict) else json.loads(value)
+    out: list[dict[str, Any]] = []
+    for e in data.get("l", []):
+        t = str(e.get("t", "")).zfill(4)
+        s = e.get("s")
+        f = e.get("f")
+        out.append(
+            {
+                "id": e.get("id"),
+                "enabled": bool(e.get("e")),
+                "time": f"{t[:2]}:{t[2:]}" if t.isdigit() and len(t) == 4 else t,
+                "days": ", ".join(
+                    _SCALAR_SCHEDULE_DAYS.get(d, d) for d in str(e.get("r", ""))
+                ),
+                "suction": (
+                    EUFY_CLEAN_NOVEL_CLEAN_SPEED[s].value
+                    if isinstance(s, int) and 0 <= s < 4
+                    else s
+                ),
+                "pattern": SCALAR_CLEAN_PATTERN_NAMES.get(f, f),
+            }
+        )
+    return out
+
+
+def _process_scalar_dnd(
+    state: VacuumState, value: Any, changes: dict[str, Any]
+) -> None:
+    """Parse scalar-protocol DND JSON: {"en":bool,"start_t":"HHMM","end_t":"HHMM"}."""
+    data = value if isinstance(value, dict) else json.loads(value)
+    if "en" in data:
+        changes["dnd_enabled"] = bool(data["en"])
+    start = str(data.get("start_t", "")).zfill(4)
+    end = str(data.get("end_t", "")).zfill(4)
+    if start.isdigit() and len(start) == 4:
+        changes["dnd_start_hour"] = int(start[:2])
+        changes["dnd_start_minute"] = int(start[2:])
+    if end.isdigit() and len(end) == 4:
+        changes["dnd_end_hour"] = int(end[:2])
+        changes["dnd_end_minute"] = int(end[2:])
+    _track_field(state, changes, "do_not_disturb")
+
+
+def _process_scalar_accessories(
+    state: VacuumState, value: Any, changes: dict[str, Any]
+) -> None:
+    """Parse scalar-protocol accessory usage-counter JSON (DPS 150) into AccessoryState.
+
+    Stores raw usage counters; conversion to % remaining happens in the sensor
+    layer (per-accessory max life). See docs/g50_capture/FINDINGS.md.
+    """
+    data = value if isinstance(value, dict) else json.loads(value)
+    accessory_changes = {
+        field: int(data[json_key])
+        for json_key, field in _SCALAR_ACCESSORY_FIELDS.items()
+        if json_key in data
+    }
+    if accessory_changes:
+        changes["accessories"] = replace(state.accessories, **accessory_changes)
+        _track_field(state, changes, "accessories")
 
 
 def _process_station_status(

--- a/custom_components/robovac_mqtt/api/parser_scalar.py
+++ b/custom_components/robovac_mqtt/api/parser_scalar.py
@@ -1,0 +1,261 @@
+"""Inbound DPS parsing for scalar (Tuya-style) protocol devices.
+
+Scalar devices (e.g. T2210/G50) send plain ints and JSON instead of the
+X-series protobuf blobs, on a different set of DPS numbers, and emit NO
+WorkStatus (DPS 153). api/parser.update_state dispatches here when
+state.api_type == "scalar". See docs/g50_capture/FINDINGS.md for the
+captured DPS schema.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import replace
+from typing import Any
+
+from ..const import (
+    EUFY_CLEAN_ERROR_CODES,
+    EUFY_CLEAN_NOVEL_CLEAN_SPEED,
+    SCALAR_CLEAN_PATTERN_NAMES,
+    SCALAR_DPS,
+    SCALAR_STATE_NAMES,
+)
+from ..models import VacuumState, track_received_field
+
+_LOGGER = logging.getLogger(__name__)
+
+# Scalar DPS keys whose JSON values map onto accessory usage counters.
+_SCALAR_ACCESSORY_FIELDS = {
+    "dust_filter": "filter_usage",
+    "roller_brush": "main_brush_usage",
+    "side_brush": "side_brush_usage",
+    "sensors": "sensor_usage",
+}
+
+_SCALAR_SCHEDULE_DAYS = {
+    "1": "Mon",
+    "2": "Tue",
+    "3": "Wed",
+    "4": "Thu",
+    "5": "Fri",
+    "6": "Sat",
+    "7": "Sun",
+}
+
+
+def _g_int(value: Any) -> int | None:
+    """Coerce a scalar DPS value to int, or None if not numeric."""
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.lstrip("-").isdigit():
+        return int(value)
+    return None
+
+
+def process_scalar_dps(
+    state: VacuumState, dps: dict[str, Any], changes: dict[str, Any]
+) -> None:
+    """Process DPS for scalar/JSON devices (e.g. T2210/G50).
+
+    Each DPS is handled independently so one bad value never aborts the batch.
+    """
+    for key, value in dps.items():
+        try:
+            if key == SCALAR_DPS["STATE"]:
+                code = _g_int(value)
+                if code is None:
+                    continue
+                changes["status_code"] = code
+                changes["activity"] = SCALAR_STATE_NAMES.get(code, "idle")
+                changes["charging"] = code == 5
+                changes["task_status"] = _map_scalar_task_status(code)
+
+            elif key == SCALAR_DPS["BATTERY"]:
+                level = _g_int(value)
+                if level is not None:
+                    changes["battery_level"] = level
+                    track_received_field(state, changes, "battery_level")
+
+            elif key == SCALAR_DPS["SUCTION"]:
+                idx = _g_int(value)
+                if idx is not None and 0 <= idx < 4:
+                    changes["fan_speed"] = EUFY_CLEAN_NOVEL_CLEAN_SPEED[idx].value
+                    track_received_field(state, changes, "fan_speed")
+
+            elif key == SCALAR_DPS["BOOST_IQ"]:
+                b = _g_int(value)
+                if b is not None:
+                    changes["boost_iq"] = bool(b)
+                    track_received_field(state, changes, "boost_iq")
+
+            elif key == SCALAR_DPS["CLEAN_PATTERN"]:
+                p = _g_int(value)
+                if p is not None and p in SCALAR_CLEAN_PATTERN_NAMES:
+                    changes["cleaning_pattern"] = SCALAR_CLEAN_PATTERN_NAMES[p]
+                    track_received_field(state, changes, "cleaning_pattern")
+
+            elif key == SCALAR_DPS["VOLUME"]:
+                v = _g_int(value)
+                if v is not None:
+                    changes["volume"] = max(0, min(100, v * 10))
+                    track_received_field(state, changes, "volume")
+
+            elif key == SCALAR_DPS["CHILD_LOCK"]:
+                c = _g_int(value)
+                if c is not None:
+                    changes["child_lock"] = bool(c)
+                    track_received_field(state, changes, "child_lock")
+
+            elif key == SCALAR_DPS["FIND_ROBOT"]:
+                f = _g_int(value)
+                if f is not None:
+                    changes["find_robot"] = bool(f)
+
+            elif key == SCALAR_DPS["DND"]:
+                _process_scalar_dnd(state, value, changes)
+
+            elif key in (SCALAR_DPS["ERROR_CODE"], SCALAR_DPS["ERROR_CODE_ALT"]):
+                code = _g_int(value)
+                if code:  # non-zero fault wins (106 and 177 are both candidates)
+                    changes["error_code"] = code
+                    changes["error_message"] = EUFY_CLEAN_ERROR_CODES.get(
+                        code, "Unknown Error"
+                    )
+                elif "error_code" not in changes:  # clear only if nothing set yet
+                    changes["error_code"] = 0
+                    changes["error_message"] = ""
+
+            elif key == SCALAR_DPS["AUTO_RETURN"]:
+                c = _g_int(value)
+                if c is not None:
+                    changes["auto_return"] = bool(c)
+                    track_received_field(state, changes, "auto_return")
+
+            elif key == SCALAR_DPS["ACTIVITY_LOG"]:
+                a = _g_int(value)
+                if a is not None:
+                    changes["activity_log_upload"] = bool(a)
+                    track_received_field(state, changes, "activity_log_upload")
+
+            elif key == SCALAR_DPS["SCHEDULE"]:
+                scheds = _parse_scalar_schedules(value)
+                if scheds is not None:
+                    changes["schedules"] = scheds
+                    track_received_field(state, changes, "schedules")
+
+            elif key == SCALAR_DPS["CLEAN_TIME"]:
+                secs = _g_int(value)  # DPS 109 is already in seconds
+                if secs is not None:
+                    changes["cleaning_time"] = secs
+                    track_received_field(state, changes, "cleaning_stats")
+
+            elif key == SCALAR_DPS["CLEAN_AREA"]:
+                area = _g_int(value)  # DPS 110 is in m²
+                if area is not None:
+                    changes["cleaning_area"] = area
+                    track_received_field(state, changes, "cleaning_stats")
+
+            elif key == SCALAR_DPS["ACCESSORIES"]:
+                _process_scalar_accessories(state, value, changes)
+
+            else:
+                _LOGGER.debug("scalar-protocol unhandled DPS %s: %s", key, value)
+
+        except Exception as e:
+            _LOGGER.warning(
+                "Error parsing scalar-protocol DPS %s: %s", key, e, exc_info=True
+            )
+
+    # DPS 122 is a motion flag (1=stationary, 0=moving). A stationary robot that
+    # is otherwise mid-clean is paused — reconcile after the loop so it doesn't
+    # matter whether 122 or 15 was processed first.
+    pause_flag = dps.get(SCALAR_DPS["PAUSE"])
+    if pause_flag is not None:
+        activity = changes.get("activity", state.activity)
+        if _g_int(pause_flag) == 1 and activity == "cleaning":
+            changes["activity"] = "paused"
+            changes["task_status"] = "Paused"
+
+
+def _map_scalar_task_status(code: int) -> str:
+    """Map scalar-protocol state int (DPS 15) to a human task-status string."""
+    return {
+        0: "Standby",
+        1: "Standby",
+        2: "Cleaning",
+        4: "Returning",
+        5: "Charging",
+        6: "Docked",
+        7: "Paused",
+    }.get(code, "Standby")
+
+
+def _parse_scalar_schedules(value: Any) -> list[dict[str, Any]] | None:
+    """Decode the DPS 151 schedule JSON into friendly read-only entries.
+
+    Raw entry: {"e":bool, "t":"HHMM", "r":"<day digits 1=Mon..7=Sun>",
+                "s":suction 0-3, "f":pattern 1/2, "id":int}.
+    """
+    data = value if isinstance(value, dict) else json.loads(value)
+    out: list[dict[str, Any]] = []
+    for e in data.get("l", []):
+        t = str(e.get("t", "")).zfill(4)
+        s = e.get("s")
+        f = e.get("f")
+        out.append(
+            {
+                "id": e.get("id"),
+                "enabled": bool(e.get("e")),
+                "time": f"{t[:2]}:{t[2:]}" if t.isdigit() and len(t) == 4 else t,
+                "days": ", ".join(
+                    _SCALAR_SCHEDULE_DAYS.get(d, d) for d in str(e.get("r", ""))
+                ),
+                "suction": (
+                    EUFY_CLEAN_NOVEL_CLEAN_SPEED[s].value
+                    if isinstance(s, int) and 0 <= s < 4
+                    else s
+                ),
+                "pattern": SCALAR_CLEAN_PATTERN_NAMES.get(f, f),
+            }
+        )
+    return out
+
+
+def _process_scalar_dnd(
+    state: VacuumState, value: Any, changes: dict[str, Any]
+) -> None:
+    """Parse scalar-protocol DND JSON: {"en":bool,"start_t":"HHMM","end_t":"HHMM"}."""
+    data = value if isinstance(value, dict) else json.loads(value)
+    if "en" in data:
+        changes["dnd_enabled"] = bool(data["en"])
+    start = str(data.get("start_t", "")).zfill(4)
+    end = str(data.get("end_t", "")).zfill(4)
+    if start.isdigit() and len(start) == 4:
+        changes["dnd_start_hour"] = int(start[:2])
+        changes["dnd_start_minute"] = int(start[2:])
+    if end.isdigit() and len(end) == 4:
+        changes["dnd_end_hour"] = int(end[:2])
+        changes["dnd_end_minute"] = int(end[2:])
+    track_received_field(state, changes, "do_not_disturb")
+
+
+def _process_scalar_accessories(
+    state: VacuumState, value: Any, changes: dict[str, Any]
+) -> None:
+    """Parse scalar-protocol accessory usage-counter JSON (DPS 150) into AccessoryState.
+
+    Stores raw usage counters; conversion to % remaining happens in the sensor
+    layer (per-accessory max life). See docs/g50_capture/FINDINGS.md.
+    """
+    data = value if isinstance(value, dict) else json.loads(value)
+    accessory_changes = {
+        field: int(data[json_key])
+        for json_key, field in _SCALAR_ACCESSORY_FIELDS.items()
+        if json_key in data
+    }
+    if accessory_changes:
+        changes["accessories"] = replace(state.accessories, **accessory_changes)
+        track_received_field(state, changes, "accessories")

--- a/custom_components/robovac_mqtt/button.py
+++ b/custom_components/robovac_mqtt/button.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import Any
 
 from homeassistant.components.button import ButtonEntity
@@ -32,53 +33,78 @@ async def async_setup_entry(
     for coordinator in coordinators:
         _LOGGER.debug("Adding buttons for %s", coordinator.device_name)
 
-        entities.extend(
-            [
-                RoboVacButton(coordinator, "Dry Mop", "_dry_mop", "go_dry"),
-                RoboVacButton(coordinator, "Wash Mop", "_wash_mop", "go_selfcleaning"),
-                RoboVacButton(
-                    coordinator, "Empty Dust Bin", "_empty_dust_bin", "collect_dust"
-                ),
-                RoboVacButton(coordinator, "Stop Dry Mop", "_stop_dry_mop", "stop_dry"),
-            ]
-        )
+        # Scalar (Tuya) devices like the G50 are vacuum-only: no station (wash/dry/
+        # dust), no mop. Skip those buttons entirely instead of leaving them dead.
+        is_scalar = coordinator.api_type == "scalar"
 
-        # Accessory Reset Buttons
+        if not is_scalar:
+            entities.extend(
+                [
+                    RoboVacButton(coordinator, "Dry Mop", "_dry_mop", "go_dry"),
+                    RoboVacButton(
+                        coordinator, "Wash Mop", "_wash_mop", "go_selfcleaning"
+                    ),
+                    RoboVacButton(
+                        coordinator, "Empty Dust Bin", "_empty_dust_bin", "collect_dust"
+                    ),
+                    RoboVacButton(
+                        coordinator, "Stop Dry Mop", "_stop_dry_mop", "stop_dry"
+                    ),
+                ]
+            )
+
+        # Accessory Reset Buttons (filter/brushes/sensor are universal).
         accessories = [
+            # (name, id_suffix, novel reset_type, icon, scalar DPS-150 key)
             (
                 "Reset Filter",
                 "_reset_filter",
                 ConsumableRequest.FILTER_MESH,
                 "mdi:air-filter",
+                "dust_filter",
             ),
             (
                 "Reset Rolling Brush",
                 "_reset_main_brush",
                 ConsumableRequest.ROLLING_BRUSH,
                 "mdi:broom",
+                "roller_brush",
             ),
             (
                 "Reset Side Brush",
                 "_reset_side_brush",
                 ConsumableRequest.SIDE_BRUSH,
                 "mdi:broom",
+                "side_brush",
             ),
             (
                 "Reset Sensors",
                 "_reset_sensors",
                 ConsumableRequest.SENSOR,
                 "mdi:eye-outline",
+                "sensors",
             ),
-            (
-                "Reset Cleaning Tray",
-                "_reset_scrape",
-                ConsumableRequest.SCRAPE,
-                "mdi:wiper",
-            ),
-            ("Reset Mopping Cloth", "_reset_mop", ConsumableRequest.MOP, "mdi:water"),
         ]
+        if not is_scalar:
+            # Cleaning tray + mopping cloth only exist on mop-capable devices.
+            accessories += [
+                (
+                    "Reset Cleaning Tray",
+                    "_reset_scrape",
+                    ConsumableRequest.SCRAPE,
+                    "mdi:wiper",
+                    None,
+                ),
+                (
+                    "Reset Mopping Cloth",
+                    "_reset_mop",
+                    ConsumableRequest.MOP,
+                    "mdi:water",
+                    None,
+                ),
+            ]
 
-        for name, suffix, reset_type, icon in accessories:
+        for name, suffix, reset_type, icon, scalar_key in accessories:
             entities.append(
                 RoboVacButton(
                     coordinator,
@@ -88,6 +114,20 @@ async def async_setup_entry(
                     icon,
                     category=EntityCategory.CONFIG,
                     reset_type=reset_type,
+                    scalar_key=scalar_key,
+                )
+            )
+
+        # Detangle roller brush — scalar/Tuya devices only (DPS 153).
+        if is_scalar:
+            entities.append(
+                RoboVacButton(
+                    coordinator,
+                    "Detangle Roller Brush",
+                    "_detangle_brush",
+                    "detangle_brush",
+                    "mdi:broom",
+                    category=EntityCategory.CONFIG,
                 )
             )
 
@@ -105,12 +145,14 @@ class RoboVacButton(CoordinatorEntity[EufyCleanCoordinator], ButtonEntity):
         command: str,
         icon: str | None = None,
         category: EntityCategory | None = None,
+        available_fn: Callable[[EufyCleanCoordinator], bool] | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize button."""
         super().__init__(coordinator)
         self._command = command
         self._command_kwargs = kwargs
+        self._available_fn = available_fn
         self._attr_unique_id = f"{coordinator.device_id}{id_suffix}"
 
         # Use Home Assistant standard naming
@@ -122,7 +164,18 @@ class RoboVacButton(CoordinatorEntity[EufyCleanCoordinator], ButtonEntity):
         if icon:
             self._attr_icon = icon
 
+    @property
+    def available(self) -> bool:
+        """Return whether the button is available."""
+        if self._available_fn is not None:
+            return super().available and self._available_fn(self.coordinator)
+        return super().available
+
     async def async_press(self) -> None:
         """Press the button."""
-        cmd = build_command(self._command, **self._command_kwargs)
+        cmd = build_command(
+            self._command,
+            api_type=self.coordinator.api_type,
+            **self._command_kwargs,
+        )
         await self.coordinator.async_send_command(cmd)

--- a/custom_components/robovac_mqtt/button.py
+++ b/custom_components/robovac_mqtt/button.py
@@ -14,9 +14,67 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .api.commands import build_command
 from .const import DOMAIN
 from .coordinator import EufyCleanCoordinator
+from .entity import API_TYPE_NOVEL, API_TYPE_SCALAR, filter_supported_entities
 from .proto.cloud.consumable_pb2 import ConsumableRequest
 
 _LOGGER = logging.getLogger(__name__)
+
+# Accessory reset buttons: (name, id_suffix, novel reset_type, icon,
+# scalar DPS-150 key, supported api types). Filter/brushes/sensor are
+# universal; cleaning tray + mopping cloth only exist on mop-capable
+# (novel) devices.
+_ACCESSORY_RESET_BUTTONS: list[
+    tuple[str, str, int, str, str | None, tuple[str, ...] | None]
+] = [
+    (
+        "Reset Filter",
+        "_reset_filter",
+        ConsumableRequest.FILTER_MESH,
+        "mdi:air-filter",
+        "dust_filter",
+        None,
+    ),
+    (
+        "Reset Rolling Brush",
+        "_reset_main_brush",
+        ConsumableRequest.ROLLING_BRUSH,
+        "mdi:broom",
+        "roller_brush",
+        None,
+    ),
+    (
+        "Reset Side Brush",
+        "_reset_side_brush",
+        ConsumableRequest.SIDE_BRUSH,
+        "mdi:broom",
+        "side_brush",
+        None,
+    ),
+    (
+        "Reset Sensors",
+        "_reset_sensors",
+        ConsumableRequest.SENSOR,
+        "mdi:eye-outline",
+        "sensors",
+        None,
+    ),
+    (
+        "Reset Cleaning Tray",
+        "_reset_scrape",
+        ConsumableRequest.SCRAPE,
+        "mdi:wiper",
+        None,
+        (API_TYPE_NOVEL,),
+    ),
+    (
+        "Reset Mopping Cloth",
+        "_reset_mop",
+        ConsumableRequest.MOP,
+        "mdi:water",
+        None,
+        (API_TYPE_NOVEL,),
+    ),
+]
 
 
 async def async_setup_entry(
@@ -33,79 +91,58 @@ async def async_setup_entry(
     for coordinator in coordinators:
         _LOGGER.debug("Adding buttons for %s", coordinator.device_name)
 
-        # Scalar (Tuya) devices like the G50 are vacuum-only: no station (wash/dry/
-        # dust), no mop. Skip those buttons entirely instead of leaving them dead.
-        is_scalar = coordinator.api_type == "scalar"
-
-        if not is_scalar:
-            entities.extend(
-                [
-                    RoboVacButton(coordinator, "Dry Mop", "_dry_mop", "go_dry"),
-                    RoboVacButton(
-                        coordinator, "Wash Mop", "_wash_mop", "go_selfcleaning"
-                    ),
-                    RoboVacButton(
-                        coordinator, "Empty Dust Bin", "_empty_dust_bin", "collect_dust"
-                    ),
-                    RoboVacButton(
-                        coordinator, "Stop Dry Mop", "_stop_dry_mop", "stop_dry"
-                    ),
-                ]
-            )
-
-        # Accessory Reset Buttons (filter/brushes/sensor are universal).
-        accessories = [
-            # (name, id_suffix, novel reset_type, icon, scalar DPS-150 key)
-            (
-                "Reset Filter",
-                "_reset_filter",
-                ConsumableRequest.FILTER_MESH,
-                "mdi:air-filter",
-                "dust_filter",
+        buttons = [
+            # Station buttons (wash/dry/dust) — scalar (Tuya) devices like the
+            # G50 are vacuum-only and have no station.
+            RoboVacButton(
+                coordinator,
+                "Dry Mop",
+                "_dry_mop",
+                "go_dry",
+                supported_api_types=(API_TYPE_NOVEL,),
             ),
-            (
-                "Reset Rolling Brush",
-                "_reset_main_brush",
-                ConsumableRequest.ROLLING_BRUSH,
+            RoboVacButton(
+                coordinator,
+                "Wash Mop",
+                "_wash_mop",
+                "go_selfcleaning",
+                supported_api_types=(API_TYPE_NOVEL,),
+            ),
+            RoboVacButton(
+                coordinator,
+                "Empty Dust Bin",
+                "_empty_dust_bin",
+                "collect_dust",
+                supported_api_types=(API_TYPE_NOVEL,),
+            ),
+            RoboVacButton(
+                coordinator,
+                "Stop Dry Mop",
+                "_stop_dry_mop",
+                "stop_dry",
+                supported_api_types=(API_TYPE_NOVEL,),
+            ),
+            # Detangle roller brush — scalar/Tuya devices only (DPS 153).
+            RoboVacButton(
+                coordinator,
+                "Detangle Roller Brush",
+                "_detangle_brush",
+                "detangle_brush",
                 "mdi:broom",
-                "roller_brush",
-            ),
-            (
-                "Reset Side Brush",
-                "_reset_side_brush",
-                ConsumableRequest.SIDE_BRUSH,
-                "mdi:broom",
-                "side_brush",
-            ),
-            (
-                "Reset Sensors",
-                "_reset_sensors",
-                ConsumableRequest.SENSOR,
-                "mdi:eye-outline",
-                "sensors",
+                category=EntityCategory.CONFIG,
+                supported_api_types=(API_TYPE_SCALAR,),
             ),
         ]
-        if not is_scalar:
-            # Cleaning tray + mopping cloth only exist on mop-capable devices.
-            accessories += [
-                (
-                    "Reset Cleaning Tray",
-                    "_reset_scrape",
-                    ConsumableRequest.SCRAPE,
-                    "mdi:wiper",
-                    None,
-                ),
-                (
-                    "Reset Mopping Cloth",
-                    "_reset_mop",
-                    ConsumableRequest.MOP,
-                    "mdi:water",
-                    None,
-                ),
-            ]
 
-        for name, suffix, reset_type, icon, scalar_key in accessories:
-            entities.append(
+        for (
+            name,
+            suffix,
+            reset_type,
+            icon,
+            scalar_key,
+            supported,
+        ) in _ACCESSORY_RESET_BUTTONS:
+            buttons.append(
                 RoboVacButton(
                     coordinator,
                     name,
@@ -113,23 +150,13 @@ async def async_setup_entry(
                     "reset_accessory",
                     icon,
                     category=EntityCategory.CONFIG,
+                    supported_api_types=supported,
                     reset_type=reset_type,
                     scalar_key=scalar_key,
                 )
             )
 
-        # Detangle roller brush — scalar/Tuya devices only (DPS 153).
-        if is_scalar:
-            entities.append(
-                RoboVacButton(
-                    coordinator,
-                    "Detangle Roller Brush",
-                    "_detangle_brush",
-                    "detangle_brush",
-                    "mdi:broom",
-                    category=EntityCategory.CONFIG,
-                )
-            )
+        entities.extend(filter_supported_entities(coordinator, buttons))
 
     async_add_entities(entities)
 
@@ -146,10 +173,13 @@ class RoboVacButton(CoordinatorEntity[EufyCleanCoordinator], ButtonEntity):
         icon: str | None = None,
         category: EntityCategory | None = None,
         available_fn: Callable[[EufyCleanCoordinator], bool] | None = None,
+        supported_api_types: tuple[str, ...] | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize button."""
         super().__init__(coordinator)
+        # DPS protocols this button exists on (see entity.py); None = all.
+        self.supported_api_types = supported_api_types
         self._command = command
         self._command_kwargs = kwargs
         self._available_fn = available_fn

--- a/custom_components/robovac_mqtt/const.py
+++ b/custom_components/robovac_mqtt/const.py
@@ -554,6 +554,79 @@ KNOWN_UNPROCESSED_DPS: frozenset[str] = frozenset(
 DPS_ROBOT_TELEMETRY = "179"
 
 
+# --- Scalar (Tuya-style) DPS protocol ---------------------------------------
+# Some Eufy models (verified: T2210 "G50") do NOT use the Anker length-prefixed
+# protobuf DPS blobs. Instead they expose state as plain integers / JSON on the
+# Tuya DPS numbers, and send NO protobuf WorkStatus. The protocol is detected at
+# runtime from value shapes (see api/cloud.py:checkApiType) — not from a model
+# list — so any cloud-only Tuya-schema device is handled generically.
+# This is a sibling of the Tuya-Cloud "legacy" path (jeppesens PR #110), but here
+# the transport is Anker MQTT and the values are ints (not strings).
+# See docs/g50_capture/FINDINGS.md for the reverse-engineering evidence and the
+# canonical Tuya DPS names (damacus/robovac).
+SCALAR_DPS = {
+    "STATE": "15",  # activity status (int Tuya STATUS)
+    "DETANGLE": "153",  # write 1 = start roller-brush detangle (read=0 in /res)
+    # DPS 5 is the work-mode command AND a reported sub-state. Captured from the
+    # app's /req: writing 5=1 starts an auto clean, 5=3 returns to the dock.
+    "WORK_MODE": "5",
+    "PAUSE": "122",  # write 1=pause, 2=resume (also a /res motion flag: 1=stationary)
+    "SUCTION": "102",  # Tuya FAN_SPEED: 0=Quiet 1=Standard 2=Turbo 3=Max
+    "FIND_ROBOT": "103",  # Tuya LOCATE: 0/1
+    "BATTERY": "104",  # Tuya BATTERY_LEVEL: 0-100 %
+    "DND": "107",  # Tuya DO_NOT_DISTURB: JSON {"en":bool,"start_t","end_t"}
+    "CLEAN_TIME": "109",  # cleaning time in SECONDS (verified: 300=5min, 780=13min)
+    "CLEAN_AREA": "110",  # cleaning area in m² (verified: 4=43ft², 3=32ft²)
+    "VOLUME": "111",  # voice volume 0-10 (=0-100% in 10% steps)
+    "BOOST_IQ": "118",  # Tuya BOOST_IQ: 0/1
+    "AUTO_RETURN": "135",  # "Auto-Return Cleaning" toggle: 0/1 (Tuya auto_return)
+    "CHILD_LOCK": "139",  # child lock: 0/1
+    "ACTIVITY_LOG": "142",  # activity-log upload toggle: 0/1
+    "SCHEDULE": "151",  # JSON {"l":[{e,t,r,s,f,id}]}
+    "CLEAN_PATTERN": "154",  # 1=Arranged 2=Random (int, NOT protobuf here)
+    "ACCESSORIES": "150",  # JSON usage counters
+    # Error code: canonical Tuya ERROR_CODE is 106; the G50 capture also showed a
+    # scalar on 177. We read both (non-zero wins) since which carries a live fault
+    # is unconfirmed.
+    "ERROR_CODE": "106",
+    "ERROR_CODE_ALT": "177",
+}
+
+# DPS 15 (scalar state int) -> activity string (same vocabulary the novel parser
+# produces, so the vacuum/binary_sensor entities consume it unchanged).
+SCALAR_STATE_NAMES = {
+    0: "idle",
+    1: "idle",
+    2: "cleaning",
+    4: "returning",
+    5: "docked",  # on dock, actively charging
+    6: "docked",  # on dock, charge complete (battery full)
+    7: "paused",
+}
+
+# Scalar suction reuses the first four EUFY_CLEAN_NOVEL_CLEAN_SPEED entries
+# (Quiet/Standard/Turbo/Max); BoostIQ is a separate switch (DPS 118), not a 5th speed.
+SCALAR_SUCTION_LEVELS = [s.value for s in EUFY_CLEAN_NOVEL_CLEAN_SPEED[:4]]
+
+# DPS 154 (scalar clean path pattern)
+SCALAR_CLEAN_PATTERN_NAMES = {1: "Arranged", 2: "Random"}
+
+# Scalar movement command values (DPS 5 work-mode), captured from the app /req.
+SCALAR_WORK_MODE_START = 1  # {"5": 1} -> start auto clean
+SCALAR_WORK_MODE_GO_HOME = 3  # {"5": 3} -> return to dock
+
+# Scalar accessory max life in HOURS. DPS 150 reports usage counters in MINUTES;
+# % remaining = 1 - used_min / (max_h * 60). Calibrated against the G50 app's
+# reported remaining-hours/percentages (see docs/g50_capture/FINDINGS.md). These
+# differ from the X-series ACCESSORY_MAX_LIFE values below.
+SCALAR_ACCESSORY_MAX_LIFE = {
+    "filter_usage": 200,
+    "main_brush_usage": 360,  # rolling brush
+    "side_brush_usage": 250,
+    "sensor_usage": 35,
+}
+
+
 ACCESSORY_MAX_LIFE = {
     "filter_usage": 360,
     "main_brush_usage": 360,

--- a/custom_components/robovac_mqtt/coordinator.py
+++ b/custom_components/robovac_mqtt/coordinator.py
@@ -52,9 +52,7 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
         )
 
         self.client: EufyCleanClient | None = None
-        self.data = VacuumState(
-            device_model=self.device_model, api_type=self.api_type
-        )
+        self.data = VacuumState(device_model=self.device_model, api_type=self.api_type)
         self._dock_idle_cancel: CALLBACK_TYPE | None = (
             None  # Timer for dock IDLE debounce
         )

--- a/custom_components/robovac_mqtt/coordinator.py
+++ b/custom_components/robovac_mqtt/coordinator.py
@@ -37,6 +37,9 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
         """Initialize coordinator."""
         self.device_id = device_info["deviceId"]
         self.device_model = device_info["deviceModel"]
+        # DPS protocol ("novel" protobuf / "scalar" Tuya-int / "legacy"),
+        # classified cloud-side by EufyLogin.checkApiType from the initial snapshot.
+        self.api_type = device_info.get("apiType", "novel")
         self.device_name = device_info["deviceName"]
         self.serial_number = device_info.get("deviceId")  # Usually deviceId is SN
         self.firmware_version = device_info.get("softVersion")
@@ -49,7 +52,9 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
         )
 
         self.client: EufyCleanClient | None = None
-        self.data = VacuumState()
+        self.data = VacuumState(
+            device_model=self.device_model, api_type=self.api_type
+        )
         self._dock_idle_cancel: CALLBACK_TYPE | None = (
             None  # Timer for dock IDLE debounce
         )

--- a/custom_components/robovac_mqtt/entity.py
+++ b/custom_components/robovac_mqtt/entity.py
@@ -1,0 +1,48 @@
+"""Shared helpers for protocol-dependent entity support.
+
+Devices speak one of two DPS protocols (see api/parser.update_state):
+"scalar" (plain Tuya-style int/JSON, e.g. T2210/G50) or "novel" (Anker
+length-prefixed protobuf, the default for everything else, including
+"legacy"/"unknown" api types).
+
+Entities declare which protocols they support via a ``supported_api_types``
+attribute — a tuple of protocol names, or ``None`` (the default) for
+universal entities. Platform setups pass their candidate entities through
+:func:`filter_supported_entities` so unsupported entities are never added
+to the registry (e.g. no scalar-only switches on X-series devices).
+"""
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+from homeassistant.helpers.entity import Entity
+
+from .coordinator import EufyCleanCoordinator
+
+API_TYPE_NOVEL = "novel"
+API_TYPE_SCALAR = "scalar"
+
+_EntityT = TypeVar("_EntityT", bound=Entity)
+
+
+def effective_api_type(api_type: str) -> str:
+    """Map a cloud-reported api type onto the two supported DPS protocols.
+
+    Anything that is not scalar (novel, legacy, unknown, ...) is parsed and
+    commanded as novel, mirroring api/parser.update_state dispatch.
+    """
+    return API_TYPE_SCALAR if api_type == API_TYPE_SCALAR else API_TYPE_NOVEL
+
+
+def filter_supported_entities(
+    coordinator: EufyCleanCoordinator, entities: list[_EntityT]
+) -> list[_EntityT]:
+    """Return only the entities supported by the device's DPS protocol."""
+    api_type = effective_api_type(coordinator.api_type)
+    return [
+        entity
+        for entity in entities
+        if (supported := getattr(entity, "supported_api_types", None)) is None
+        or api_type in supported
+    ]

--- a/custom_components/robovac_mqtt/manifest.json
+++ b/custom_components/robovac_mqtt/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/jeppesens/eufy-clean/issues",
   "requirements": [],
-  "version": "1.9.2"
+  "version": "1.10.0"
 }

--- a/custom_components/robovac_mqtt/models.py
+++ b/custom_components/robovac_mqtt/models.py
@@ -33,6 +33,16 @@ class AccessoryState:
 class VacuumState:
     """Represent the complete state of a Eufy vacuum."""
 
+    # Device identity (used for the HA device registry).
+    device_model: str = ""
+
+    # DPS protocol variant, classified cloud-side by EufyLogin.checkApiType and
+    # seeded by the coordinator at init:
+    #   "novel"  -> Anker protobuf DPS (X-series, default)
+    #   "scalar" -> plain int/JSON Tuya-style DPS over MQTT (e.g. T2210/G50)
+    #   "legacy" -> pure Tuya cloud devices (PR #110; no parser here yet)
+    api_type: str = "novel"
+
     # Basic
     activity: str = "idle"  # cleaning, docked, error, etc.
     battery_level: int = 0
@@ -86,6 +96,14 @@ class VacuumState:
     carpet_strategy: str = "Auto Raise"  # Clean carpet strategy from DPS 154
     corner_cleaning: str = "Normal"  # Mop corner cleaning from DPS 154
     smart_mode: bool = False  # Smart mode switch from DPS 154
+
+    # scalar-protocol fields (e.g. T2210/G50)
+    boost_iq: bool = False  # BoostIQ auto-carpet-boost (scalar-protocol DPS 118)
+    volume: int = 0  # Voice volume 0-100% (scalar-protocol DPS 111, 0-10 *10)
+    cleaning_pattern: str = "Arranged"  # Path pattern Arranged/Random (scalar-protocol DPS 154)
+    auto_return: bool = False  # "Auto-Return Cleaning" toggle (DPS 135)
+    activity_log_upload: bool = False  # Activity-log upload toggle (DPS 142)
+    schedules: list[dict[str, Any]] = field(default_factory=list)  # DPS 151 (read-only)
 
     # Device settings (from DPS 176 UnisettingResponse)
     wifi_signal: float = -100.0  # AP signal strength in dBm (converted from 0-100%)

--- a/custom_components/robovac_mqtt/models.py
+++ b/custom_components/robovac_mqtt/models.py
@@ -100,7 +100,9 @@ class VacuumState:
     # scalar-protocol fields (e.g. T2210/G50)
     boost_iq: bool = False  # BoostIQ auto-carpet-boost (scalar-protocol DPS 118)
     volume: int = 0  # Voice volume 0-100% (scalar-protocol DPS 111, 0-10 *10)
-    cleaning_pattern: str = "Arranged"  # Path pattern Arranged/Random (scalar-protocol DPS 154)
+    cleaning_pattern: str = (
+        "Arranged"  # Path pattern Arranged/Random (scalar-protocol DPS 154)
+    )
     auto_return: bool = False  # "Auto-Return Cleaning" toggle (DPS 135)
     activity_log_upload: bool = False  # Activity-log upload toggle (DPS 142)
     schedules: list[dict[str, Any]] = field(default_factory=list)  # DPS 151 (read-only)
@@ -129,3 +131,18 @@ class VacuumState:
     # Track which optional fields have ever been received from the device
     # Used by sensors to determine availability (e.g., water level on C20)
     received_fields: set[str] = field(default_factory=set)
+
+
+def track_received_field(
+    state: VacuumState, changes: dict[str, Any], field_name: str
+) -> None:
+    """Record in *changes* that a field has been received from the device.
+
+    This feeds VacuumState.received_fields, which sensors use to determine
+    availability. Only updates if the field isn't already tracked.
+    """
+    if field_name not in state.received_fields:
+        # Get current set from changes if already modified, else from state
+        current = changes.get("received_fields", state.received_fields).copy()
+        current.add(field_name)
+        changes["received_fields"] = current

--- a/custom_components/robovac_mqtt/number.py
+++ b/custom_components/robovac_mqtt/number.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import copy
 import logging
 from collections.abc import Callable
+from dataclasses import replace
 from typing import Any
 
 from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -33,23 +34,28 @@ async def async_setup_entry(
     for coordinator in coordinators:
         _LOGGER.debug("Adding number entities for %s", coordinator.device_name)
 
-        # Wash Frequency Value
-        entities.append(
-            DockNumberEntity(
-                coordinator,
-                "wash_frequency_value",
-                "Wash Frequency Value (Time)",
-                15,
-                25,
-                1,  # step
-                lambda cfg: cfg.get("wash", {})
-                .get("wash_freq", {})
-                .get("time_or_area", {})
-                .get("value", 15),
-                _set_wash_freq_value,
-                icon="mdi:clock-time-four-outline",
+        # Wash Frequency Value — station/mop feature; skip on scalar (Tuya)
+        # vacuum-only devices like the G50.
+        if coordinator.api_type != "scalar":
+            entities.append(
+                DockNumberEntity(
+                    coordinator,
+                    "wash_frequency_value",
+                    "Wash Frequency Value (Time)",
+                    15,
+                    25,
+                    1,  # step
+                    lambda cfg: cfg.get("wash", {})
+                    .get("wash_freq", {})
+                    .get("time_or_area", {})
+                    .get("value", 15),
+                    _set_wash_freq_value,
+                    icon="mdi:clock-time-four-outline",
+                )
             )
-        )
+
+        # Voice volume (scalar-protocol, DPS 111). Hidden until reported.
+        entities.append(VolumeNumberEntity(coordinator))
 
     async_add_entities(entities)
 
@@ -123,3 +129,41 @@ class DockNumberEntity(CoordinatorEntity[EufyCleanCoordinator], NumberEntity):
 
         command = build_command("set_auto_cfg", cfg=cfg)
         await self.coordinator.async_send_command(command)
+
+
+class VolumeNumberEntity(CoordinatorEntity[EufyCleanCoordinator], NumberEntity):
+    """Voice volume control (scalar-protocol, DPS 111: 0-10 = 0-100% in 10% steps)."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Voice Volume"
+    _attr_icon = "mdi:volume-high"
+    _attr_native_min_value = 0
+    _attr_native_max_value = 100
+    _attr_native_step = 10
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: EufyCleanCoordinator) -> None:
+        """Initialize the volume number entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.device_id}_volume"
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    def available(self) -> bool:
+        """Return whether the entity is available."""
+        return super().available and "volume" in self.coordinator.data.received_fields
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current volume percentage."""
+        return self.coordinator.data.volume
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the volume (percentage, rounded to nearest 10%)."""
+        pct = max(0, min(100, round(value / 10) * 10))
+        command = build_command("set_volume", volume=pct)
+        await self.coordinator.async_send_command(command)
+        self.coordinator.async_set_updated_data(
+            replace(self.coordinator.data, volume=pct)
+        )

--- a/custom_components/robovac_mqtt/number.py
+++ b/custom_components/robovac_mqtt/number.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .api.commands import build_command
 from .const import DOMAIN
 from .coordinator import EufyCleanCoordinator
+from .entity import API_TYPE_NOVEL, API_TYPE_SCALAR, filter_supported_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,28 +35,28 @@ async def async_setup_entry(
     for coordinator in coordinators:
         _LOGGER.debug("Adding number entities for %s", coordinator.device_name)
 
-        # Wash Frequency Value — station/mop feature; skip on scalar (Tuya)
-        # vacuum-only devices like the G50.
-        if coordinator.api_type != "scalar":
-            entities.append(
-                DockNumberEntity(
-                    coordinator,
-                    "wash_frequency_value",
-                    "Wash Frequency Value (Time)",
-                    15,
-                    25,
-                    1,  # step
-                    lambda cfg: cfg.get("wash", {})
-                    .get("wash_freq", {})
-                    .get("time_or_area", {})
-                    .get("value", 15),
-                    _set_wash_freq_value,
-                    icon="mdi:clock-time-four-outline",
-                )
+        entities.extend(
+            filter_supported_entities(
+                coordinator,
+                [
+                    DockNumberEntity(
+                        coordinator,
+                        "wash_frequency_value",
+                        "Wash Frequency Value (Time)",
+                        15,
+                        25,
+                        1,  # step
+                        lambda cfg: cfg.get("wash", {})
+                        .get("wash_freq", {})
+                        .get("time_or_area", {})
+                        .get("value", 15),
+                        _set_wash_freq_value,
+                        icon="mdi:clock-time-four-outline",
+                    ),
+                    VolumeNumberEntity(coordinator),
+                ],
             )
-
-        # Voice volume (scalar-protocol, DPS 111). Hidden until reported.
-        entities.append(VolumeNumberEntity(coordinator))
+        )
 
     async_add_entities(entities)
 
@@ -74,7 +75,13 @@ def _set_wash_freq_value(cfg: dict[str, Any], val: float) -> None:
 
 
 class DockNumberEntity(CoordinatorEntity[EufyCleanCoordinator], NumberEntity):
-    """Number entity for Dock settings."""
+    """Number entity for Dock settings.
+
+    Station/mop features; scalar (Tuya) vacuum-only devices like the G50 have
+    no station.
+    """
+
+    supported_api_types = (API_TYPE_NOVEL,)
 
     def __init__(
         self,
@@ -133,6 +140,8 @@ class DockNumberEntity(CoordinatorEntity[EufyCleanCoordinator], NumberEntity):
 
 class VolumeNumberEntity(CoordinatorEntity[EufyCleanCoordinator], NumberEntity):
     """Voice volume control (scalar-protocol, DPS 111: 0-10 = 0-100% in 10% steps)."""
+
+    supported_api_types = (API_TYPE_SCALAR,)
 
     _attr_has_entity_name = True
     _attr_name = "Voice Volume"

--- a/custom_components/robovac_mqtt/select.py
+++ b/custom_components/robovac_mqtt/select.py
@@ -21,6 +21,8 @@ from .const import (
     EUFY_CLEAN_CLEANING_MODES,
     EUFY_CLEAN_NOVEL_CLEAN_SPEED,
     EUFY_CLEAN_WATER_LEVELS,
+    SCALAR_CLEAN_PATTERN_NAMES,
+    SCALAR_SUCTION_LEVELS,
 )
 from .coordinator import EufyCleanCoordinator
 
@@ -73,7 +75,15 @@ async def async_setup_entry(
     for coordinator in coordinators:
         _LOGGER.debug("Adding select entities for %s", coordinator.device_name)
 
+        # Suction + cleaning pattern apply to all (incl. scalar/Tuya vacuums).
         entities.append(SuctionLevelSelectEntity(coordinator))
+        entities.append(CleaningPatternSelectEntity(coordinator))
+
+        # The rest are mop / station / map selects that scalar (Tuya) vacuum-only
+        # devices like the G50 don't have — skip them there.
+        if coordinator.api_type == "scalar":
+            continue
+
         entities.append(CleaningModeSelectEntity(coordinator))
         entities.append(WaterLevelSelectEntity(coordinator))
         entities.append(MopIntensitySelectEntity(coordinator))
@@ -398,7 +408,11 @@ class _StateBackedSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEn
 
         state_value = self._option_to_state(option)
         await self.coordinator.async_send_command(
-            build_command(self._command_name, **{self._command_arg_name: state_value})
+            build_command(
+                self._command_name,
+                api_type=self.coordinator.data.api_type,
+                **{self._command_arg_name: state_value},
+            )
         )
         _optimistically_update_state(
             self.coordinator,
@@ -427,6 +441,10 @@ class SuctionLevelSelectEntity(_StateBackedSelectEntity):
     def __init__(self, coordinator: EufyCleanCoordinator) -> None:
         """Initialize suction level select."""
         super().__init__(coordinator, "suction_level")
+        # scalar-protocol (scalar protocol) devices expose BoostIQ as a separate switch
+        # (DPS 118), so their suction list is the four levels without Boost_IQ.
+        if coordinator.data.api_type == "scalar":
+            self._attr_options = SCALAR_SUCTION_LEVELS
 
 
 class CleaningModeSelectEntity(_StateBackedSelectEntity):
@@ -449,6 +467,29 @@ class CleaningModeSelectEntity(_StateBackedSelectEntity):
     def __init__(self, coordinator: EufyCleanCoordinator) -> None:
         """Initialize cleaning mode select."""
         super().__init__(coordinator, "cleaning_mode")
+
+
+class CleaningPatternSelectEntity(_StateBackedSelectEntity):
+    """Select entity for the cleaning path pattern (Arranged/Random).
+
+    scalar-protocol only (DPS 154 int). Distinct from CleaningModeSelectEntity, which is
+    the X-series Vacuum/Mop axis. Hidden until a pattern value is reported.
+    """
+
+    _attr_has_entity_name = True
+    _attr_name = "Cleaning Pattern"
+    _attr_icon = "mdi:vector-polyline"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_options = list(SCALAR_CLEAN_PATTERN_NAMES.values())
+    _command_name = "set_cleaning_pattern"
+    _command_arg_name = "pattern"
+    _state_field = "cleaning_pattern"
+    _available_field = "cleaning_pattern"
+    _log_label = "Cleaning pattern"
+
+    def __init__(self, coordinator: EufyCleanCoordinator) -> None:
+        """Initialize cleaning pattern select."""
+        super().__init__(coordinator, "cleaning_pattern")
 
 
 class WaterLevelSelectEntity(_StateBackedSelectEntity):

--- a/custom_components/robovac_mqtt/select.py
+++ b/custom_components/robovac_mqtt/select.py
@@ -25,6 +25,7 @@ from .const import (
     SCALAR_SUCTION_LEVELS,
 )
 from .coordinator import EufyCleanCoordinator
+from .entity import API_TYPE_NOVEL, API_TYPE_SCALAR, filter_supported_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -75,62 +76,53 @@ async def async_setup_entry(
     for coordinator in coordinators:
         _LOGGER.debug("Adding select entities for %s", coordinator.device_name)
 
-        # Suction + cleaning pattern apply to all (incl. scalar/Tuya vacuums).
-        entities.append(SuctionLevelSelectEntity(coordinator))
-        entities.append(CleaningPatternSelectEntity(coordinator))
-
-        # The rest are mop / station / map selects that scalar (Tuya) vacuum-only
-        # devices like the G50 don't have — skip them there.
-        if coordinator.api_type == "scalar":
-            continue
-
-        entities.append(CleaningModeSelectEntity(coordinator))
-        entities.append(WaterLevelSelectEntity(coordinator))
-        entities.append(MopIntensitySelectEntity(coordinator))
-        entities.append(CleaningIntensitySelectEntity(coordinator))
-        entities.append(SceneSelectEntity(coordinator))
-        entities.append(RoomSelectEntity(coordinator))
-
-        entities.append(
-            DockSelectEntity(
+        entities.extend(
+            filter_supported_entities(
                 coordinator,
-                "wash_frequency_mode",
-                "Wash Frequency Mode",
-                ["ByRoom", "ByTime"],
-                lambda cfg: (
-                    "ByRoom"
-                    if cfg.get("wash", {})
-                    .get("wash_freq", {})
-                    .get("mode", "ByPartition")
-                    == "ByPartition"
-                    else "ByTime"
-                ),
-                _set_wash_freq_mode,
-                icon="mdi:calendar-sync",
-            )
-        )
-
-        entities.append(
-            DockSelectEntity(
-                coordinator,
-                "dry_duration",
-                "Dry Duration",
-                list(DRY_DURATION_MAP.values()),
-                _get_dry_duration,
-                _set_dry_duration,
-                icon="mdi:timer-sand",
-            )
-        )
-
-        entities.append(
-            DockSelectEntity(
-                coordinator,
-                "auto_empty_mode",
-                "Auto Empty Mode",
-                ["Smart", "15 min", "30 min", "45 min", "60 min"],
-                _get_collect_dust_mode,
-                _set_collect_dust_mode,
-                icon="mdi:delete-restore",
+                [
+                    SuctionLevelSelectEntity(coordinator),
+                    CleaningPatternSelectEntity(coordinator),
+                    CleaningModeSelectEntity(coordinator),
+                    WaterLevelSelectEntity(coordinator),
+                    MopIntensitySelectEntity(coordinator),
+                    CleaningIntensitySelectEntity(coordinator),
+                    SceneSelectEntity(coordinator),
+                    RoomSelectEntity(coordinator),
+                    DockSelectEntity(
+                        coordinator,
+                        "wash_frequency_mode",
+                        "Wash Frequency Mode",
+                        ["ByRoom", "ByTime"],
+                        lambda cfg: (
+                            "ByRoom"
+                            if cfg.get("wash", {})
+                            .get("wash_freq", {})
+                            .get("mode", "ByPartition")
+                            == "ByPartition"
+                            else "ByTime"
+                        ),
+                        _set_wash_freq_mode,
+                        icon="mdi:calendar-sync",
+                    ),
+                    DockSelectEntity(
+                        coordinator,
+                        "dry_duration",
+                        "Dry Duration",
+                        list(DRY_DURATION_MAP.values()),
+                        _get_dry_duration,
+                        _set_dry_duration,
+                        icon="mdi:timer-sand",
+                    ),
+                    DockSelectEntity(
+                        coordinator,
+                        "auto_empty_mode",
+                        "Auto Empty Mode",
+                        ["Smart", "15 min", "30 min", "45 min", "60 min"],
+                        _get_collect_dust_mode,
+                        _set_collect_dust_mode,
+                        icon="mdi:delete-restore",
+                    ),
+                ],
             )
         )
 
@@ -200,7 +192,13 @@ def _set_collect_dust_mode(cfg: dict[str, Any], val: str) -> None:
 
 
 class DockSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
-    """Configuration select for Dock/Station settings."""
+    """Configuration select for Dock/Station settings.
+
+    Station features; scalar (Tuya) vacuum-only devices like the G50 have no
+    station.
+    """
+
+    supported_api_types = (API_TYPE_NOVEL,)
 
     def __init__(
         self,
@@ -256,6 +254,8 @@ class DockSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
 class SceneSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
     """Select entity for choosing and triggering cleaning scenes."""
 
+    supported_api_types = (API_TYPE_NOVEL,)
+
     def __init__(self, coordinator: EufyCleanCoordinator) -> None:
         """Initialize scene select."""
         super().__init__(coordinator)
@@ -309,6 +309,8 @@ class SceneSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
 
 class RoomSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
     """Select entity for choosing and triggering room cleaning."""
+
+    supported_api_types = (API_TYPE_NOVEL,)
 
     def __init__(self, coordinator: EufyCleanCoordinator) -> None:
         """Initialize room select."""
@@ -453,6 +455,8 @@ class CleaningModeSelectEntity(_StateBackedSelectEntity):
     Hidden until a cleaning mode value is reported from DPS 154.
     """
 
+    supported_api_types = (API_TYPE_NOVEL,)
+
     _attr_has_entity_name = True
     _attr_name = "Cleaning Mode"
     _attr_icon = "mdi:spray-bottle"
@@ -475,6 +479,8 @@ class CleaningPatternSelectEntity(_StateBackedSelectEntity):
     scalar-protocol only (DPS 154 int). Distinct from CleaningModeSelectEntity, which is
     the X-series Vacuum/Mop axis. Hidden until a pattern value is reported.
     """
+
+    supported_api_types = (API_TYPE_SCALAR,)
 
     _attr_has_entity_name = True
     _attr_name = "Cleaning Pattern"
@@ -502,6 +508,8 @@ class WaterLevelSelectEntity(_StateBackedSelectEntity):
     the Matter bridge discovers MopIntensitySelectEntity.
     """
 
+    supported_api_types = (API_TYPE_NOVEL,)
+
     _attr_has_entity_name = True
     _attr_name = "Water Level"
     _attr_icon = "mdi:water"
@@ -526,6 +534,8 @@ class MopIntensitySelectEntity(_StateBackedSelectEntity):
     to align with standard Matter enums, even though 'Quiet' is not a
     typical word for water level. 'Automatic' maps to 'Medium' as a safe fallback.
     """
+
+    supported_api_types = (API_TYPE_NOVEL,)
 
     _attr_has_entity_name = True
     _attr_name = "Mop Intensity"
@@ -555,6 +565,8 @@ class MopIntensitySelectEntity(_StateBackedSelectEntity):
 
 class CleaningIntensitySelectEntity(_StateBackedSelectEntity):
     """Select entity for adjusting global cleaning intensity."""
+
+    supported_api_types = (API_TYPE_NOVEL,)
 
     _attr_has_entity_name = True
     _attr_name = "Cleaning Intensity"

--- a/custom_components/robovac_mqtt/sensor.py
+++ b/custom_components/robovac_mqtt/sensor.py
@@ -19,7 +19,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ACCESSORY_MAX_LIFE, DOMAIN
+from .const import (
+    ACCESSORY_MAX_LIFE,
+    DOMAIN,
+    SCALAR_ACCESSORY_MAX_LIFE,
+)
 from .coordinator import EufyCleanCoordinator, VacuumState
 
 _LOGGER = logging.getLogger(__name__)
@@ -94,20 +98,21 @@ async def async_setup_entry(
             )
         )
 
-        # Work Mode Sensor
-        entities.append(
-            RoboVacSensor(
-                coordinator,
-                "work_mode",
-                "Work Mode",
-                lambda s: s.work_mode,
-                device_class=None,
-                unit=None,
-                state_class=None,
-                icon="mdi:cog-outline",
-                category=EntityCategory.DIAGNOSTIC,
+        # Work Mode Sensor (novel WorkStatus mode; scalar G50 has no equivalent)
+        if coordinator.api_type != "scalar":
+            entities.append(
+                RoboVacSensor(
+                    coordinator,
+                    "work_mode",
+                    "Work Mode",
+                    lambda s: s.work_mode,
+                    device_class=None,
+                    unit=None,
+                    state_class=None,
+                    icon="mdi:cog-outline",
+                    category=EntityCategory.DIAGNOSTIC,
+                )
             )
-        )
 
         # Cleaning Time Sensor
         entities.append(
@@ -121,10 +126,14 @@ async def async_setup_entry(
                 state_class=SensorStateClass.MEASUREMENT,
                 icon="mdi:clock-outline",
                 availability_fn=lambda s: "cleaning_stats" in s.received_fields,
+                # Stored in seconds; default the display to whole minutes.
+                suggested_unit_of_measurement="min",
+                suggested_display_precision=0,
             )
         )
 
-        # Cleaning Area Sensor
+        # Cleaning Area Sensor (verified: scalar DPS 110 = m², 4=43ft²/3=32ft²;
+        # X-series via cleaning stats).
         entities.append(
             RoboVacSensor(
                 coordinator,
@@ -136,181 +145,230 @@ async def async_setup_entry(
                 state_class=SensorStateClass.MEASUREMENT,
                 icon="mdi:floor-plan",
                 availability_fn=lambda s: "cleaning_stats" in s.received_fields,
+                suggested_display_precision=0,
             )
         )
 
-        # Water level sensor (Station Clean Water)
-        # Uses availability_fn to hide sensor on devices that don't report water level
-        entities.append(
-            RoboVacSensor(
-                coordinator,
-                "water_level",
-                "Water Level",
-                lambda s: s.station_clean_water,
-                device_class=None,
-                unit=PERCENTAGE,
-                state_class=SensorStateClass.MEASUREMENT,
-                availability_fn=lambda s: "station_clean_water" in s.received_fields,
+        # Station / map sensors — scalar (Tuya) vacuum-only devices like the G50
+        # have no station and no maps, so skip these entirely there.
+        if coordinator.api_type != "scalar":
+            # Water level sensor (Station Clean Water)
+            entities.append(
+                RoboVacSensor(
+                    coordinator,
+                    "water_level",
+                    "Water Level",
+                    lambda s: s.station_clean_water,
+                    device_class=None,
+                    unit=PERCENTAGE,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    availability_fn=lambda s: "station_clean_water"
+                    in s.received_fields,
+                )
             )
-        )
 
-        # Dock status sensor
+            # Dock status sensor
+            entities.append(
+                RoboVacSensor(
+                    coordinator,
+                    "dock_status",
+                    "Dock Status",
+                    lambda s: s.dock_status,
+                    device_class=None,
+                    unit=None,
+                    state_class=None,
+                    category=EntityCategory.DIAGNOSTIC,
+                    availability_fn=lambda s: "dock_status" in s.received_fields,
+                )
+            )
+
+            # Active map ID sensor
+            entities.append(
+                RoboVacSensor(
+                    coordinator,
+                    "active_map",
+                    "Active Map",
+                    lambda s: s.map_id,
+                    device_class=None,
+                    unit=None,
+                    state_class=None,
+                    icon="mdi:map-marker-path",
+                    category=EntityCategory.DIAGNOSTIC,
+                    availability_fn=lambda s: "map_id" in s.received_fields,
+                )
+            )
+
+            # Active cleaning target sensor
+            entities.append(
+                RoboVacSensor(
+                    coordinator,
+                    "active_cleaning_target",
+                    "Active Cleaning Target",
+                    _active_rooms_value,
+                    device_class=None,
+                    unit=None,
+                    state_class=None,
+                    icon="mdi:floor-plan",
+                    category=EntityCategory.DIAGNOSTIC,
+                    availability_fn=_active_rooms_available,
+                    extra_state_attributes_fn=lambda s: {
+                        "room_ids": s.active_room_ids,
+                        "scene_id": s.current_scene_id,
+                        "scene_name": s.current_scene_name,
+                        "zone_count": s.active_zone_count,
+                    },
+                )
+            )
+
+        # WiFi + robot-position diagnostics come from novel-only DPS (169/176/179);
+        # scalar (Tuya) devices like the G50 never report them — skip there.
+        if coordinator.api_type != "scalar":
+            # WiFi Signal Strength (from DPS 176 UnisettingResponse)
+            entities.append(
+                RoboVacSensor(
+                    coordinator,
+                    "wifi_signal",
+                    "WiFi Signal Strength",
+                    lambda s: s.wifi_signal,
+                    device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                    unit=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    icon="mdi:wifi",
+                    category=EntityCategory.DIAGNOSTIC,
+                    availability_fn=lambda s: "wifi_signal" in s.received_fields,
+                    enabled_default=False,
+                )
+            )
+
+            # WiFi SSID (from DPS 169 DeviceInfo)
+            entities.append(
+                RoboVacSensor(
+                    coordinator,
+                    "wifi_ssid",
+                    "WiFi SSID",
+                    lambda s: s.wifi_ssid or None,
+                    icon="mdi:wifi",
+                    category=EntityCategory.DIAGNOSTIC,
+                    availability_fn=lambda s: "wifi_ssid" in s.received_fields,
+                    enabled_default=False,
+                )
+            )
+
+            # WiFi IP Address (from DPS 169 DeviceInfo)
+            entities.append(
+                RoboVacSensor(
+                    coordinator,
+                    "wifi_ip",
+                    "IP Address",
+                    lambda s: s.wifi_ip or None,
+                    icon="mdi:ip-network",
+                    category=EntityCategory.DIAGNOSTIC,
+                    availability_fn=lambda s: "wifi_ip" in s.received_fields,
+                    enabled_default=False,
+                )
+            )
+
+            # Robot Position - raw (from DPS 179 telemetry, diagnostic)
+            entities.append(
+                RoboVacSensor(
+                    coordinator,
+                    "robot_position_x",
+                    "Robot Position X (raw)",
+                    lambda s: s.robot_position_x,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    icon="mdi:crosshairs-gps",
+                    category=EntityCategory.DIAGNOSTIC,
+                    availability_fn=lambda s: "robot_position" in s.received_fields,
+                    enabled_default=False,
+                )
+            )
+
+            entities.append(
+                RoboVacSensor(
+                    coordinator,
+                    "robot_position_y",
+                    "Robot Position Y (raw)",
+                    lambda s: s.robot_position_y,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    icon="mdi:crosshairs-gps",
+                    category=EntityCategory.DIAGNOSTIC,
+                    availability_fn=lambda s: "robot_position" in s.received_fields,
+                    enabled_default=False,
+                )
+            )
+
+        # Schedules (read-only; scalar/Tuya devices, DPS 151). State = entry
+        # count; the decoded entries are exposed as attributes.
         entities.append(
             RoboVacSensor(
                 coordinator,
-                "dock_status",
-                "Dock Status",
-                lambda s: s.dock_status,
+                "schedules",
+                "Schedules",
+                lambda s: len(s.schedules),
                 device_class=None,
                 unit=None,
                 state_class=None,
+                icon="mdi:calendar-clock",
                 category=EntityCategory.DIAGNOSTIC,
-                availability_fn=lambda s: "dock_status" in s.received_fields,
+                availability_fn=lambda s: "schedules" in s.received_fields,
+                extra_state_attributes_fn=lambda s: {"entries": s.schedules},
             )
         )
 
-        # Active map ID sensor
-        entities.append(
-            RoboVacSensor(
-                coordinator,
-                "active_map",
-                "Active Map",
-                lambda s: s.map_id,
-                device_class=None,
-                unit=None,
-                state_class=None,
-                icon="mdi:map-marker-path",
-                category=EntityCategory.DIAGNOSTIC,
-                availability_fn=lambda s: "map_id" in s.received_fields,
-            )
-        )
-
-        # Active cleaning target sensor
-        entities.append(
-            RoboVacSensor(
-                coordinator,
-                "active_cleaning_target",
-                "Active Cleaning Target",
-                _active_rooms_value,
-                device_class=None,
-                unit=None,
-                state_class=None,
-                icon="mdi:floor-plan",
-                category=EntityCategory.DIAGNOSTIC,
-                availability_fn=_active_rooms_available,
-                extra_state_attributes_fn=lambda s: {
-                    "room_ids": s.active_room_ids,
-                    "scene_id": s.current_scene_id,
-                    "scene_name": s.current_scene_name,
-                    "zone_count": s.active_zone_count,
-                },
-            )
-        )
-
-        # WiFi Signal Strength (from DPS 176 UnisettingResponse)
-        entities.append(
-            RoboVacSensor(
-                coordinator,
-                "wifi_signal",
-                "WiFi Signal Strength",
-                lambda s: s.wifi_signal,
-                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
-                unit=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-                state_class=SensorStateClass.MEASUREMENT,
-                icon="mdi:wifi",
-                category=EntityCategory.DIAGNOSTIC,
-                availability_fn=lambda s: "wifi_signal" in s.received_fields,
-                enabled_default=False,
-            )
-        )
-
-        # WiFi SSID (from DPS 169 DeviceInfo)
-        entities.append(
-            RoboVacSensor(
-                coordinator,
-                "wifi_ssid",
-                "WiFi SSID",
-                lambda s: s.wifi_ssid or None,
-                icon="mdi:wifi",
-                category=EntityCategory.DIAGNOSTIC,
-                availability_fn=lambda s: "wifi_ssid" in s.received_fields,
-                enabled_default=False,
-            )
-        )
-
-        # WiFi IP Address (from DPS 169 DeviceInfo)
-        entities.append(
-            RoboVacSensor(
-                coordinator,
-                "wifi_ip",
-                "IP Address",
-                lambda s: s.wifi_ip or None,
-                icon="mdi:ip-network",
-                category=EntityCategory.DIAGNOSTIC,
-                availability_fn=lambda s: "wifi_ip" in s.received_fields,
-                enabled_default=False,
-            )
-        )
-
-        # Robot Position - raw (from DPS 179 telemetry, diagnostic)
-        entities.append(
-            RoboVacSensor(
-                coordinator,
-                "robot_position_x",
-                "Robot Position X (raw)",
-                lambda s: s.robot_position_x,
-                state_class=SensorStateClass.MEASUREMENT,
-                icon="mdi:crosshairs-gps",
-                category=EntityCategory.DIAGNOSTIC,
-                availability_fn=lambda s: "robot_position" in s.received_fields,
-                enabled_default=False,
-            )
-        )
-
-        entities.append(
-            RoboVacSensor(
-                coordinator,
-                "robot_position_y",
-                "Robot Position Y (raw)",
-                lambda s: s.robot_position_y,
-                state_class=SensorStateClass.MEASUREMENT,
-                icon="mdi:crosshairs-gps",
-                category=EntityCategory.DIAGNOSTIC,
-                availability_fn=lambda s: "robot_position" in s.received_fields,
-                enabled_default=False,
-            )
-        )
-
-        # Accessory Sensors
+        # Accessory Sensors. Filter/brushes/sensor are universal; cleaning tray
+        # and mopping cloth only exist on mop-capable (non-scalar) devices.
         accessories = [
             ("filter_usage", "Filter Remaining", "mdi:air-filter"),
             ("main_brush_usage", "Rolling Brush Remaining", "mdi:broom"),
             ("side_brush_usage", "Side Brush Remaining", "mdi:broom"),
             ("sensor_usage", "Sensor Remaining", "mdi:eye-outline"),
-            ("scrape_usage", "Cleaning Tray Remaining", "mdi:wiper"),
-            ("mop_usage", "Mopping Cloth Remaining", "mdi:water"),
         ]
+        if coordinator.api_type != "scalar":
+            accessories += [
+                ("scrape_usage", "Cleaning Tray Remaining", "mdi:wiper"),
+                ("mop_usage", "Mopping Cloth Remaining", "mdi:water"),
+            ]
 
         for attr, name, icon in accessories:
             # We must capture the specific attr value in the lambda default args
-            # otherwise all lambdas will point to the last attr in the loop
-            def get_accessory_remaining(state: VacuumState, a: str = attr) -> int:
+            # otherwise all lambdas will point to the last attr in the loop.
+            # X-series report usage in hours; scalar-protocol (scalar protocol) report
+            # usage in MINUTES with their own per-accessory max life (hours).
+            def get_accessory_remaining(state: VacuumState, a: str = attr) -> int | None:
                 usage = getattr(state.accessories, a) or 0
+                if state.api_type == "scalar":
+                    max_h = SCALAR_ACCESSORY_MAX_LIFE.get(a)
+                    if not max_h:
+                        return None  # accessory not present on this device
+                    return max(0, round(max_h - usage / 60))
                 max_life = ACCESSORY_MAX_LIFE.get(a, 0)
                 # Ensure we don't go negative if usage exceeds defaults
                 return max(0, max_life - usage)
 
-            max_life_val = ACCESSORY_MAX_LIFE.get(attr, 0)
-
             # Extra attributes explicitly using specific attr
-            def get_attributes(
-                state: VacuumState, a: str = attr, m: int = max_life_val
-            ) -> dict[str, Any]:
+            def get_attributes(state: VacuumState, a: str = attr) -> dict[str, Any]:
                 usage = getattr(state.accessories, a) or 0
+                if state.api_type == "scalar":
+                    max_h = SCALAR_ACCESSORY_MAX_LIFE.get(a, 0)
+                    used_h = usage / 60
+                    pct = max(0, round(100 * (1 - used_h / max_h))) if max_h else None
+                    return {
+                        "usage_hours": round(used_h, 1),
+                        "total_life_hours": max_h,
+                        "percent_remaining": pct,
+                    }
                 return {
                     "usage_hours": usage,
-                    "total_life_hours": m,
+                    "total_life_hours": ACCESSORY_MAX_LIFE.get(a, 0),
                 }
+
+            def accessory_available(state: VacuumState, a: str = attr) -> bool:
+                if "accessories" not in state.received_fields:
+                    return False
+                if state.api_type == "scalar":
+                    # Hide accessories the scalar-protocol device doesn't have (mop, tray)
+                    return a in SCALAR_ACCESSORY_MAX_LIFE
+                return True
 
             entities.append(
                 RoboVacSensor(
@@ -324,7 +382,7 @@ async def async_setup_entry(
                     icon=icon,
                     category=EntityCategory.DIAGNOSTIC,
                     extra_state_attributes_fn=get_attributes,
-                    availability_fn=lambda s: "accessories" in s.received_fields,
+                    availability_fn=accessory_available,
                 )
             )
 
@@ -351,6 +409,7 @@ class RoboVacSensor(CoordinatorEntity[EufyCleanCoordinator], SensorEntity):
         availability_fn: Callable[[VacuumState], bool] | None = None,
         enabled_default: bool = True,
         suggested_display_precision: int | None = None,
+        suggested_unit_of_measurement: str | None = None,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
@@ -377,6 +436,8 @@ class RoboVacSensor(CoordinatorEntity[EufyCleanCoordinator], SensorEntity):
             self._attr_icon = icon
         if suggested_display_precision is not None:
             self._attr_suggested_display_precision = suggested_display_precision
+        if suggested_unit_of_measurement is not None:
+            self._attr_suggested_unit_of_measurement = suggested_unit_of_measurement
 
     @property
     def available(self) -> bool:

--- a/custom_components/robovac_mqtt/sensor.py
+++ b/custom_components/robovac_mqtt/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
+    UnitOfArea,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -25,6 +26,7 @@ from .const import (
     SCALAR_ACCESSORY_MAX_LIFE,
 )
 from .coordinator import EufyCleanCoordinator, VacuumState
+from .entity import API_TYPE_NOVEL, API_TYPE_SCALAR, filter_supported_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,11 +67,10 @@ async def async_setup_entry(
     for coordinator in coordinators:
         _LOGGER.debug("Adding sensors for %s", coordinator.device_name)
 
-        # Battery sensor
-        entities.append(BatterySensorEntity(coordinator))
-
-        # Error Message Sensor
-        entities.append(
+        sensors: list[SensorEntity] = [
+            # Battery sensor
+            BatterySensorEntity(coordinator),
+            # Error Message Sensor
             RoboVacSensor(
                 coordinator,
                 "error_message",
@@ -80,11 +81,8 @@ async def async_setup_entry(
                 state_class=None,
                 icon="mdi:alert-circle-outline",
                 category=EntityCategory.DIAGNOSTIC,
-            )
-        )
-
-        # Task Status Sensor
-        entities.append(
+            ),
+            # Task Status Sensor
             RoboVacSensor(
                 coordinator,
                 "task_status",
@@ -95,27 +93,22 @@ async def async_setup_entry(
                 state_class=None,
                 icon="mdi:robot-vacuum",
                 category=EntityCategory.DIAGNOSTIC,
-            )
-        )
-
-        # Work Mode Sensor (novel WorkStatus mode; scalar G50 has no equivalent)
-        if coordinator.api_type != "scalar":
-            entities.append(
-                RoboVacSensor(
-                    coordinator,
-                    "work_mode",
-                    "Work Mode",
-                    lambda s: s.work_mode,
-                    device_class=None,
-                    unit=None,
-                    state_class=None,
-                    icon="mdi:cog-outline",
-                    category=EntityCategory.DIAGNOSTIC,
-                )
-            )
-
-        # Cleaning Time Sensor
-        entities.append(
+            ),
+            # Work Mode Sensor (novel WorkStatus mode; scalar G50 has no
+            # equivalent)
+            RoboVacSensor(
+                coordinator,
+                "work_mode",
+                "Work Mode",
+                lambda s: s.work_mode,
+                device_class=None,
+                unit=None,
+                state_class=None,
+                icon="mdi:cog-outline",
+                category=EntityCategory.DIAGNOSTIC,
+                supported_api_types=(API_TYPE_NOVEL,),
+            ),
+            # Cleaning Time Sensor
             RoboVacSensor(
                 coordinator,
                 "cleaning_time",
@@ -129,177 +122,150 @@ async def async_setup_entry(
                 # Stored in seconds; default the display to whole minutes.
                 suggested_unit_of_measurement="min",
                 suggested_display_precision=0,
-            )
-        )
-
-        # Cleaning Area Sensor (verified: scalar DPS 110 = m², 4=43ft²/3=32ft²;
-        # X-series via cleaning stats).
-        entities.append(
+            ),
+            # Cleaning Area Sensor (verified: scalar DPS 110 = m²,
+            # 4=43ft²/3=32ft²; X-series via cleaning stats).
             RoboVacSensor(
                 coordinator,
                 "cleaning_area",
                 "Cleaning Area",
                 lambda s: s.cleaning_area,
-                device_class=None,
-                unit="m²",
+                device_class=SensorDeviceClass.AREA,
+                unit=UnitOfArea.SQUARE_METERS,
                 state_class=SensorStateClass.MEASUREMENT,
                 icon="mdi:floor-plan",
                 availability_fn=lambda s: "cleaning_stats" in s.received_fields,
                 suggested_display_precision=0,
-            )
-        )
-
-        # Station / map sensors — scalar (Tuya) vacuum-only devices like the G50
-        # have no station and no maps, so skip these entirely there.
-        if coordinator.api_type != "scalar":
+            ),
+            # Station / map sensors — scalar (Tuya) vacuum-only devices like
+            # the G50 have no station and no maps.
             # Water level sensor (Station Clean Water)
-            entities.append(
-                RoboVacSensor(
-                    coordinator,
-                    "water_level",
-                    "Water Level",
-                    lambda s: s.station_clean_water,
-                    device_class=None,
-                    unit=PERCENTAGE,
-                    state_class=SensorStateClass.MEASUREMENT,
-                    availability_fn=lambda s: "station_clean_water"
-                    in s.received_fields,
-                )
-            )
-
+            RoboVacSensor(
+                coordinator,
+                "water_level",
+                "Water Level",
+                lambda s: s.station_clean_water,
+                device_class=None,
+                unit=PERCENTAGE,
+                state_class=SensorStateClass.MEASUREMENT,
+                availability_fn=lambda s: "station_clean_water" in s.received_fields,
+                supported_api_types=(API_TYPE_NOVEL,),
+            ),
             # Dock status sensor
-            entities.append(
-                RoboVacSensor(
-                    coordinator,
-                    "dock_status",
-                    "Dock Status",
-                    lambda s: s.dock_status,
-                    device_class=None,
-                    unit=None,
-                    state_class=None,
-                    category=EntityCategory.DIAGNOSTIC,
-                    availability_fn=lambda s: "dock_status" in s.received_fields,
-                )
-            )
-
+            RoboVacSensor(
+                coordinator,
+                "dock_status",
+                "Dock Status",
+                lambda s: s.dock_status,
+                device_class=None,
+                unit=None,
+                state_class=None,
+                category=EntityCategory.DIAGNOSTIC,
+                availability_fn=lambda s: "dock_status" in s.received_fields,
+                supported_api_types=(API_TYPE_NOVEL,),
+            ),
             # Active map ID sensor
-            entities.append(
-                RoboVacSensor(
-                    coordinator,
-                    "active_map",
-                    "Active Map",
-                    lambda s: s.map_id,
-                    device_class=None,
-                    unit=None,
-                    state_class=None,
-                    icon="mdi:map-marker-path",
-                    category=EntityCategory.DIAGNOSTIC,
-                    availability_fn=lambda s: "map_id" in s.received_fields,
-                )
-            )
-
+            RoboVacSensor(
+                coordinator,
+                "active_map",
+                "Active Map",
+                lambda s: s.map_id,
+                device_class=None,
+                unit=None,
+                state_class=None,
+                icon="mdi:map-marker-path",
+                category=EntityCategory.DIAGNOSTIC,
+                availability_fn=lambda s: "map_id" in s.received_fields,
+                supported_api_types=(API_TYPE_NOVEL,),
+            ),
             # Active cleaning target sensor
-            entities.append(
-                RoboVacSensor(
-                    coordinator,
-                    "active_cleaning_target",
-                    "Active Cleaning Target",
-                    _active_rooms_value,
-                    device_class=None,
-                    unit=None,
-                    state_class=None,
-                    icon="mdi:floor-plan",
-                    category=EntityCategory.DIAGNOSTIC,
-                    availability_fn=_active_rooms_available,
-                    extra_state_attributes_fn=lambda s: {
-                        "room_ids": s.active_room_ids,
-                        "scene_id": s.current_scene_id,
-                        "scene_name": s.current_scene_name,
-                        "zone_count": s.active_zone_count,
-                    },
-                )
-            )
-
-        # WiFi + robot-position diagnostics come from novel-only DPS (169/176/179);
-        # scalar (Tuya) devices like the G50 never report them — skip there.
-        if coordinator.api_type != "scalar":
+            RoboVacSensor(
+                coordinator,
+                "active_cleaning_target",
+                "Active Cleaning Target",
+                _active_rooms_value,
+                device_class=None,
+                unit=None,
+                state_class=None,
+                icon="mdi:floor-plan",
+                category=EntityCategory.DIAGNOSTIC,
+                availability_fn=_active_rooms_available,
+                extra_state_attributes_fn=lambda s: {
+                    "room_ids": s.active_room_ids,
+                    "scene_id": s.current_scene_id,
+                    "scene_name": s.current_scene_name,
+                    "zone_count": s.active_zone_count,
+                },
+                supported_api_types=(API_TYPE_NOVEL,),
+            ),
+            # WiFi + robot-position diagnostics come from novel-only DPS
+            # (169/176/179); scalar (Tuya) devices never report them.
             # WiFi Signal Strength (from DPS 176 UnisettingResponse)
-            entities.append(
-                RoboVacSensor(
-                    coordinator,
-                    "wifi_signal",
-                    "WiFi Signal Strength",
-                    lambda s: s.wifi_signal,
-                    device_class=SensorDeviceClass.SIGNAL_STRENGTH,
-                    unit=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-                    state_class=SensorStateClass.MEASUREMENT,
-                    icon="mdi:wifi",
-                    category=EntityCategory.DIAGNOSTIC,
-                    availability_fn=lambda s: "wifi_signal" in s.received_fields,
-                    enabled_default=False,
-                )
-            )
-
+            RoboVacSensor(
+                coordinator,
+                "wifi_signal",
+                "WiFi Signal Strength",
+                lambda s: s.wifi_signal,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                unit=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+                state_class=SensorStateClass.MEASUREMENT,
+                icon="mdi:wifi",
+                category=EntityCategory.DIAGNOSTIC,
+                availability_fn=lambda s: "wifi_signal" in s.received_fields,
+                enabled_default=False,
+                supported_api_types=(API_TYPE_NOVEL,),
+            ),
             # WiFi SSID (from DPS 169 DeviceInfo)
-            entities.append(
-                RoboVacSensor(
-                    coordinator,
-                    "wifi_ssid",
-                    "WiFi SSID",
-                    lambda s: s.wifi_ssid or None,
-                    icon="mdi:wifi",
-                    category=EntityCategory.DIAGNOSTIC,
-                    availability_fn=lambda s: "wifi_ssid" in s.received_fields,
-                    enabled_default=False,
-                )
-            )
-
+            RoboVacSensor(
+                coordinator,
+                "wifi_ssid",
+                "WiFi SSID",
+                lambda s: s.wifi_ssid or None,
+                icon="mdi:wifi",
+                category=EntityCategory.DIAGNOSTIC,
+                availability_fn=lambda s: "wifi_ssid" in s.received_fields,
+                enabled_default=False,
+                supported_api_types=(API_TYPE_NOVEL,),
+            ),
             # WiFi IP Address (from DPS 169 DeviceInfo)
-            entities.append(
-                RoboVacSensor(
-                    coordinator,
-                    "wifi_ip",
-                    "IP Address",
-                    lambda s: s.wifi_ip or None,
-                    icon="mdi:ip-network",
-                    category=EntityCategory.DIAGNOSTIC,
-                    availability_fn=lambda s: "wifi_ip" in s.received_fields,
-                    enabled_default=False,
-                )
-            )
-
+            RoboVacSensor(
+                coordinator,
+                "wifi_ip",
+                "IP Address",
+                lambda s: s.wifi_ip or None,
+                icon="mdi:ip-network",
+                category=EntityCategory.DIAGNOSTIC,
+                availability_fn=lambda s: "wifi_ip" in s.received_fields,
+                enabled_default=False,
+                supported_api_types=(API_TYPE_NOVEL,),
+            ),
             # Robot Position - raw (from DPS 179 telemetry, diagnostic)
-            entities.append(
-                RoboVacSensor(
-                    coordinator,
-                    "robot_position_x",
-                    "Robot Position X (raw)",
-                    lambda s: s.robot_position_x,
-                    state_class=SensorStateClass.MEASUREMENT,
-                    icon="mdi:crosshairs-gps",
-                    category=EntityCategory.DIAGNOSTIC,
-                    availability_fn=lambda s: "robot_position" in s.received_fields,
-                    enabled_default=False,
-                )
-            )
-
-            entities.append(
-                RoboVacSensor(
-                    coordinator,
-                    "robot_position_y",
-                    "Robot Position Y (raw)",
-                    lambda s: s.robot_position_y,
-                    state_class=SensorStateClass.MEASUREMENT,
-                    icon="mdi:crosshairs-gps",
-                    category=EntityCategory.DIAGNOSTIC,
-                    availability_fn=lambda s: "robot_position" in s.received_fields,
-                    enabled_default=False,
-                )
-            )
-
-        # Schedules (read-only; scalar/Tuya devices, DPS 151). State = entry
-        # count; the decoded entries are exposed as attributes.
-        entities.append(
+            RoboVacSensor(
+                coordinator,
+                "robot_position_x",
+                "Robot Position X (raw)",
+                lambda s: s.robot_position_x,
+                state_class=SensorStateClass.MEASUREMENT,
+                icon="mdi:crosshairs-gps",
+                category=EntityCategory.DIAGNOSTIC,
+                availability_fn=lambda s: "robot_position" in s.received_fields,
+                enabled_default=False,
+                supported_api_types=(API_TYPE_NOVEL,),
+            ),
+            RoboVacSensor(
+                coordinator,
+                "robot_position_y",
+                "Robot Position Y (raw)",
+                lambda s: s.robot_position_y,
+                state_class=SensorStateClass.MEASUREMENT,
+                icon="mdi:crosshairs-gps",
+                category=EntityCategory.DIAGNOSTIC,
+                availability_fn=lambda s: "robot_position" in s.received_fields,
+                enabled_default=False,
+                supported_api_types=(API_TYPE_NOVEL,),
+            ),
+            # Schedules (read-only; scalar/Tuya devices, DPS 151). State =
+            # entry count; the decoded entries are exposed as attributes.
             RoboVacSensor(
                 coordinator,
                 "schedules",
@@ -312,29 +278,34 @@ async def async_setup_entry(
                 category=EntityCategory.DIAGNOSTIC,
                 availability_fn=lambda s: "schedules" in s.received_fields,
                 extra_state_attributes_fn=lambda s: {"entries": s.schedules},
-            )
-        )
+                supported_api_types=(API_TYPE_SCALAR,),
+            ),
+        ]
 
         # Accessory Sensors. Filter/brushes/sensor are universal; cleaning tray
-        # and mopping cloth only exist on mop-capable (non-scalar) devices.
+        # and mopping cloth only exist on mop-capable (novel) devices.
         accessories = [
-            ("filter_usage", "Filter Remaining", "mdi:air-filter"),
-            ("main_brush_usage", "Rolling Brush Remaining", "mdi:broom"),
-            ("side_brush_usage", "Side Brush Remaining", "mdi:broom"),
-            ("sensor_usage", "Sensor Remaining", "mdi:eye-outline"),
+            ("filter_usage", "Filter Remaining", "mdi:air-filter", None),
+            ("main_brush_usage", "Rolling Brush Remaining", "mdi:broom", None),
+            ("side_brush_usage", "Side Brush Remaining", "mdi:broom", None),
+            ("sensor_usage", "Sensor Remaining", "mdi:eye-outline", None),
+            (
+                "scrape_usage",
+                "Cleaning Tray Remaining",
+                "mdi:wiper",
+                (API_TYPE_NOVEL,),
+            ),
+            ("mop_usage", "Mopping Cloth Remaining", "mdi:water", (API_TYPE_NOVEL,)),
         ]
-        if coordinator.api_type != "scalar":
-            accessories += [
-                ("scrape_usage", "Cleaning Tray Remaining", "mdi:wiper"),
-                ("mop_usage", "Mopping Cloth Remaining", "mdi:water"),
-            ]
 
-        for attr, name, icon in accessories:
+        for attr, name, icon, supported_api_types in accessories:
             # We must capture the specific attr value in the lambda default args
             # otherwise all lambdas will point to the last attr in the loop.
             # X-series report usage in hours; scalar-protocol (scalar protocol) report
             # usage in MINUTES with their own per-accessory max life (hours).
-            def get_accessory_remaining(state: VacuumState, a: str = attr) -> int | None:
+            def get_accessory_remaining(
+                state: VacuumState, a: str = attr
+            ) -> int | None:
                 usage = getattr(state.accessories, a) or 0
                 if state.api_type == "scalar":
                     max_h = SCALAR_ACCESSORY_MAX_LIFE.get(a)
@@ -370,7 +341,7 @@ async def async_setup_entry(
                     return a in SCALAR_ACCESSORY_MAX_LIFE
                 return True
 
-            entities.append(
+            sensors.append(
                 RoboVacSensor(
                     coordinator,
                     attr.replace("_usage", "_remaining"),
@@ -383,8 +354,11 @@ async def async_setup_entry(
                     category=EntityCategory.DIAGNOSTIC,
                     extra_state_attributes_fn=get_attributes,
                     availability_fn=accessory_available,
+                    supported_api_types=supported_api_types,
                 )
             )
+
+        entities.extend(filter_supported_entities(coordinator, sensors))
 
     async_add_entities(entities)
 
@@ -410,9 +384,12 @@ class RoboVacSensor(CoordinatorEntity[EufyCleanCoordinator], SensorEntity):
         enabled_default: bool = True,
         suggested_display_precision: int | None = None,
         suggested_unit_of_measurement: str | None = None,
+        supported_api_types: tuple[str, ...] | None = None,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
+        # DPS protocols this sensor exists on (see entity.py); None = all.
+        self.supported_api_types = supported_api_types
         self._value_fn = value_fn
         self._extra_attrs_fn = extra_state_attributes_fn
         self._availability_fn = availability_fn

--- a/custom_components/robovac_mqtt/switch.py
+++ b/custom_components/robovac_mqtt/switch.py
@@ -34,33 +34,39 @@ async def async_setup_entry(
     for coordinator in coordinators:
         _LOGGER.debug("Adding switch entities for %s", coordinator.device_name)
 
-        entities.append(
-            DockSwitchEntity(
-                coordinator,
-                "auto_empty",
-                "Auto Empty",
-                lambda cfg: cfg.get("collectdust_v2", {})
-                .get("sw", {})
-                .get("value", False),
-                set_collect_dust,
-                icon="mdi:delete-restore",
+        # Auto-empty / auto-wash are station features; scalar (Tuya) vacuum-only
+        # devices like the G50 have no station — skip them there.
+        if coordinator.api_type != "scalar":
+            entities.append(
+                DockSwitchEntity(
+                    coordinator,
+                    "auto_empty",
+                    "Auto Empty",
+                    lambda cfg: cfg.get("collectdust_v2", {})
+                    .get("sw", {})
+                    .get("value", False),
+                    set_collect_dust,
+                    icon="mdi:delete-restore",
+                )
             )
-        )
 
-        entities.append(
-            DockSwitchEntity(
-                coordinator,
-                "auto_wash",
-                "Auto Wash",
-                lambda cfg: cfg.get("wash", {}).get("cfg", "CLOSE") == "STANDARD",
-                set_wash_cfg,
-                icon="mdi:water-sync",
+            entities.append(
+                DockSwitchEntity(
+                    coordinator,
+                    "auto_wash",
+                    "Auto Wash",
+                    lambda cfg: cfg.get("wash", {}).get("cfg", "CLOSE") == "STANDARD",
+                    set_wash_cfg,
+                    icon="mdi:water-sync",
+                )
             )
-        )
 
         entities.append(DoNotDisturbSwitchEntity(coordinator))
         entities.append(ChildLockSwitchEntity(coordinator))
         entities.append(FindRobotSwitchEntity(coordinator))
+        entities.append(BoostIQSwitchEntity(coordinator))
+        entities.append(AutoReturnSwitchEntity(coordinator))
+        entities.append(ActivityLogSwitchEntity(coordinator))
 
     async_add_entities(entities)
 
@@ -175,12 +181,16 @@ class FindRobotSwitchEntity(CoordinatorEntity[EufyCleanCoordinator], SwitchEntit
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        command = build_command("find_robot", active=True)
+        command = build_command(
+            "find_robot", api_type=self.coordinator.data.api_type, active=True
+        )
         await self.coordinator.async_send_command(command)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        command = build_command("find_robot", active=False)
+        command = build_command(
+            "find_robot", api_type=self.coordinator.data.api_type, active=False
+        )
         await self.coordinator.async_send_command(command)
 
 
@@ -219,7 +229,11 @@ class ChildLockSwitchEntity(CoordinatorEntity[EufyCleanCoordinator], SwitchEntit
 
     async def _set_state(self, state: bool) -> None:
         """Send child lock command and optimistically update state."""
-        command = build_command("set_child_lock", active=state)
+        command = build_command(
+            "set_child_lock",
+            api_type=self.coordinator.data.api_type,
+            active=state,
+        )
         await self.coordinator.async_send_command(command)
         self.coordinator.async_set_updated_data(
             replace(self.coordinator.data, child_lock=state)
@@ -273,8 +287,128 @@ class DoNotDisturbSwitchEntity(CoordinatorEntity[EufyCleanCoordinator], SwitchEn
         """Send DND command and optimistically update state."""
         schedule = _current_dnd_schedule(self.coordinator)
         schedule["active"] = state
-        command = build_command("set_do_not_disturb", **schedule)
+        command = build_command(
+            "set_do_not_disturb",
+            api_type=self.coordinator.data.api_type,
+            **schedule,
+        )
         await self.coordinator.async_send_command(command)
         self.coordinator.async_set_updated_data(
             replace(self.coordinator.data, dnd_enabled=state)
         )
+
+
+class BoostIQSwitchEntity(CoordinatorEntity[EufyCleanCoordinator], SwitchEntity):
+    """Switch for BoostIQ (auto carpet suction boost).
+
+    scalar-protocol only (DPS 118). X-series lumps BoostIQ into the fan-speed list, so
+    this entity stays unavailable there (boost_iq is never reported).
+    """
+
+    def __init__(self, coordinator: EufyCleanCoordinator) -> None:
+        """Initialize the BoostIQ switch."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.device_id}_boost_iq"
+        self._attr_has_entity_name = True
+        self._attr_name = "BoostIQ"
+        self._attr_icon = "mdi:car-turbocharger"
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if BoostIQ is enabled."""
+        return self.coordinator.data.boost_iq
+
+    @property
+    def available(self) -> bool:
+        """Return whether the entity is available."""
+        return super().available and "boost_iq" in self.coordinator.data.received_fields
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable BoostIQ."""
+        await self._set_state(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable BoostIQ."""
+        await self._set_state(False)
+
+    async def _set_state(self, state: bool) -> None:
+        """Send BoostIQ command and optimistically update state."""
+        command = build_command("set_boost_iq", active=state)
+        await self.coordinator.async_send_command(command)
+        self.coordinator.async_set_updated_data(
+            replace(self.coordinator.data, boost_iq=state)
+        )
+
+
+class _ScalarToggleSwitchEntity(CoordinatorEntity[EufyCleanCoordinator], SwitchEntity):
+    """Base for simple scalar-protocol on/off switches backed by a state bool.
+
+    Subclasses set _state_field, _available_field, _command_name + the display
+    attrs. Hidden until the field is reported (scalar devices only).
+    """
+
+    _state_field: str
+    _available_field: str
+    _command_name: str
+
+    def __init__(self, coordinator: EufyCleanCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_has_entity_name = True
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    def is_on(self) -> bool | None:
+        return getattr(self.coordinator.data, self._state_field)
+
+    @property
+    def available(self) -> bool:
+        return (
+            super().available
+            and self._available_field in self.coordinator.data.received_fields
+        )
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self._set_state(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self._set_state(False)
+
+    async def _set_state(self, state: bool) -> None:
+        await self.coordinator.async_send_command(
+            build_command(self._command_name, active=state)
+        )
+        self.coordinator.async_set_updated_data(
+            replace(self.coordinator.data, **{self._state_field: state})
+        )
+
+
+class AutoReturnSwitchEntity(_ScalarToggleSwitchEntity):
+    """"Auto-Return Cleaning" toggle (scalar DPS 135)."""
+
+    _state_field = "auto_return"
+    _available_field = "auto_return"
+    _command_name = "set_auto_return"
+
+    def __init__(self, coordinator: EufyCleanCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.device_id}_auto_return"
+        self._attr_name = "Auto-Return Cleaning"
+        self._attr_icon = "mdi:tune"
+        self._attr_entity_category = EntityCategory.CONFIG
+
+
+class ActivityLogSwitchEntity(_ScalarToggleSwitchEntity):
+    """Activity-log upload toggle (scalar DPS 142)."""
+
+    _state_field = "activity_log_upload"
+    _available_field = "activity_log_upload"
+    _command_name = "set_activity_log"
+
+    def __init__(self, coordinator: EufyCleanCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.device_id}_activity_log_upload"
+        self._attr_name = "Activity Log Upload"
+        self._attr_icon = "mdi:upload"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC

--- a/custom_components/robovac_mqtt/switch.py
+++ b/custom_components/robovac_mqtt/switch.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .api.commands import build_command
 from .const import DOMAIN
 from .coordinator import EufyCleanCoordinator
+from .entity import API_TYPE_NOVEL, API_TYPE_SCALAR, filter_supported_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,39 +35,38 @@ async def async_setup_entry(
     for coordinator in coordinators:
         _LOGGER.debug("Adding switch entities for %s", coordinator.device_name)
 
-        # Auto-empty / auto-wash are station features; scalar (Tuya) vacuum-only
-        # devices like the G50 have no station — skip them there.
-        if coordinator.api_type != "scalar":
-            entities.append(
-                DockSwitchEntity(
-                    coordinator,
-                    "auto_empty",
-                    "Auto Empty",
-                    lambda cfg: cfg.get("collectdust_v2", {})
-                    .get("sw", {})
-                    .get("value", False),
-                    set_collect_dust,
-                    icon="mdi:delete-restore",
-                )
+        entities.extend(
+            filter_supported_entities(
+                coordinator,
+                [
+                    DockSwitchEntity(
+                        coordinator,
+                        "auto_empty",
+                        "Auto Empty",
+                        lambda cfg: cfg.get("collectdust_v2", {})
+                        .get("sw", {})
+                        .get("value", False),
+                        set_collect_dust,
+                        icon="mdi:delete-restore",
+                    ),
+                    DockSwitchEntity(
+                        coordinator,
+                        "auto_wash",
+                        "Auto Wash",
+                        lambda cfg: cfg.get("wash", {}).get("cfg", "CLOSE")
+                        == "STANDARD",
+                        set_wash_cfg,
+                        icon="mdi:water-sync",
+                    ),
+                    DoNotDisturbSwitchEntity(coordinator),
+                    ChildLockSwitchEntity(coordinator),
+                    FindRobotSwitchEntity(coordinator),
+                    BoostIQSwitchEntity(coordinator),
+                    AutoReturnSwitchEntity(coordinator),
+                    ActivityLogSwitchEntity(coordinator),
+                ],
             )
-
-            entities.append(
-                DockSwitchEntity(
-                    coordinator,
-                    "auto_wash",
-                    "Auto Wash",
-                    lambda cfg: cfg.get("wash", {}).get("cfg", "CLOSE") == "STANDARD",
-                    set_wash_cfg,
-                    icon="mdi:water-sync",
-                )
-            )
-
-        entities.append(DoNotDisturbSwitchEntity(coordinator))
-        entities.append(ChildLockSwitchEntity(coordinator))
-        entities.append(FindRobotSwitchEntity(coordinator))
-        entities.append(BoostIQSwitchEntity(coordinator))
-        entities.append(AutoReturnSwitchEntity(coordinator))
-        entities.append(ActivityLogSwitchEntity(coordinator))
+        )
 
     async_add_entities(entities)
 
@@ -103,7 +103,13 @@ def _current_dnd_schedule(coordinator: EufyCleanCoordinator) -> dict[str, int | 
 
 
 class DockSwitchEntity(CoordinatorEntity[EufyCleanCoordinator], SwitchEntity):
-    """Switch for Dock/Station settings."""
+    """Switch for Dock/Station settings.
+
+    Station features; scalar (Tuya) vacuum-only devices like the G50 have no
+    station.
+    """
+
+    supported_api_types = (API_TYPE_NOVEL,)
 
     def __init__(
         self,
@@ -301,9 +307,11 @@ class DoNotDisturbSwitchEntity(CoordinatorEntity[EufyCleanCoordinator], SwitchEn
 class BoostIQSwitchEntity(CoordinatorEntity[EufyCleanCoordinator], SwitchEntity):
     """Switch for BoostIQ (auto carpet suction boost).
 
-    scalar-protocol only (DPS 118). X-series lumps BoostIQ into the fan-speed list, so
-    this entity stays unavailable there (boost_iq is never reported).
+    scalar-protocol only (DPS 118). X-series lumps BoostIQ into the fan-speed
+    list, so this entity is not created there.
     """
+
+    supported_api_types = (API_TYPE_SCALAR,)
 
     def __init__(self, coordinator: EufyCleanCoordinator) -> None:
         """Initialize the BoostIQ switch."""
@@ -349,6 +357,8 @@ class _ScalarToggleSwitchEntity(CoordinatorEntity[EufyCleanCoordinator], SwitchE
     attrs. Hidden until the field is reported (scalar devices only).
     """
 
+    supported_api_types = (API_TYPE_SCALAR,)
+
     _state_field: str
     _available_field: str
     _command_name: str
@@ -385,7 +395,7 @@ class _ScalarToggleSwitchEntity(CoordinatorEntity[EufyCleanCoordinator], SwitchE
 
 
 class AutoReturnSwitchEntity(_ScalarToggleSwitchEntity):
-    """"Auto-Return Cleaning" toggle (scalar DPS 135)."""
+    """ "Auto-Return Cleaning" toggle (scalar DPS 135)."""
 
     _state_field = "auto_return"
     _available_field = "auto_return"

--- a/custom_components/robovac_mqtt/time.py
+++ b/custom_components/robovac_mqtt/time.py
@@ -74,6 +74,7 @@ class _DoNotDisturbTimeEntity(CoordinatorEntity[EufyCleanCoordinator], TimeEntit
         data = self.coordinator.data
         command = build_command(
             "set_do_not_disturb",
+            api_type=self.coordinator.data.api_type,
             active=data.dnd_enabled,
             begin_hour=(
                 value.hour if self._field_prefix == "dnd_start" else data.dnd_start_hour

--- a/custom_components/robovac_mqtt/utils.py
+++ b/custom_components/robovac_mqtt/utils.py
@@ -10,6 +10,20 @@ from google.protobuf.message import Message
 T = TypeVar("T", bound=Message)
 
 
+def is_protobuf_dps_value(value: Any) -> bool:
+    """Heuristic: does a DPS value look like an Anker base64 protobuf blob?
+
+    Anker "novel" DPS arrive as non-numeric base64 strings (e.g. "CgYI..."). The
+    Tuya "scalar" protocol reuses the same DPS *numbers* with plain ints, numeric
+    strings, or JSON objects. Used to tell the two protocols apart.
+    """
+    return (
+        isinstance(value, str)
+        and not value.lstrip("-").isdigit()
+        and not value.startswith("{")
+    )
+
+
 def decode(to_type: type[T], b64_data: str, has_length: bool = True) -> T:
     data = b64decode(b64_data)
 

--- a/custom_components/robovac_mqtt/vacuum.py
+++ b/custom_components/robovac_mqtt/vacuum.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.issue_registry import (
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api.commands import build_command
-from .const import DOMAIN, EUFY_CLEAN_NOVEL_CLEAN_SPEED
+from .const import DOMAIN, EUFY_CLEAN_NOVEL_CLEAN_SPEED, SCALAR_SUCTION_LEVELS
 from .coordinator import EufyCleanCoordinator
 
 if TYPE_CHECKING:
@@ -145,9 +145,14 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
 
         self._attr_device_info = coordinator.device_info
 
-        self._attr_fan_speed_list: list[str] = [
-            speed.value for speed in EUFY_CLEAN_NOVEL_CLEAN_SPEED
-        ]
+        # Scalar (G50) suction is Quiet/Standard/Turbo/Max; BoostIQ is a separate
+        # switch (DPS 118), not a 5th fan speed.
+        if coordinator.api_type == "scalar":
+            self._attr_fan_speed_list: list[str] = list(SCALAR_SUCTION_LEVELS)
+        else:
+            self._attr_fan_speed_list = [
+                speed.value for speed in EUFY_CLEAN_NOVEL_CLEAN_SPEED
+            ]
         # Initialize last seen segments if this is the first time and segments are available
         if config_entry:
             self._initialize_last_seen_segments()
@@ -379,6 +384,11 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
     def supported_features(self) -> VacuumEntityFeature:
         """Return the features supported by the vacuum."""
         supported_features = _BASE_SUPPORTED_FEATURES
+        if self.coordinator.api_type == "scalar":
+            # Vacuum-only Tuya device (e.g. G50): no maps/areas and no spot clean.
+            # Drop CLEAN_SPOT (unsupported) and never advertise CLEAN_AREA, so the
+            # UI doesn't offer "cleaning by area" (there are no rooms to map).
+            return supported_features & ~VacuumEntityFeature.CLEAN_SPOT
         if _CLEAN_AREA_FEATURE is not None:
             supported_features |= _CLEAN_AREA_FEATURE
         return supported_features
@@ -417,24 +427,39 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
             "segments": segments,
         }
 
+    @property
+    def _api_type(self) -> str:
+        """The coordinator's detected DPS protocol ("novel"/"scalar")."""
+        return self.coordinator.data.api_type
+
     async def async_return_to_base(self, **kwargs: Any) -> None:
         """Set the vacuum cleaner to return to the dock."""
-        await self.coordinator.async_send_command(build_command("return_to_base"))
+        await self.coordinator.async_send_command(
+            build_command("return_to_base", api_type=self._api_type)
+        )
 
     async def async_start(self, **kwargs: Any) -> None:
         """Start or resume the cleaning task."""
         if self.activity == VacuumActivity.PAUSED:
-            await self.coordinator.async_send_command(build_command("play"))
+            await self.coordinator.async_send_command(
+                build_command("play", api_type=self._api_type)
+            )
         else:
-            await self.coordinator.async_send_command(build_command("start_auto"))
+            await self.coordinator.async_send_command(
+                build_command("start_auto", api_type=self._api_type)
+            )
 
     async def async_pause(self, **kwargs: Any) -> None:
         """Pause the cleaning task."""
-        await self.coordinator.async_send_command(build_command("pause"))
+        await self.coordinator.async_send_command(
+            build_command("pause", api_type=self._api_type)
+        )
 
     async def async_stop(self, **kwargs: Any) -> None:
         """Stop the cleaning task."""
-        await self.coordinator.async_send_command(build_command("stop"))
+        await self.coordinator.async_send_command(
+            build_command("stop", api_type=self._api_type)
+        )
 
     async def async_clean_spot(self, **kwargs: Any) -> None:
         """Perform a spot clean-up."""
@@ -443,7 +468,11 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
     async def async_locate(self, **kwargs: Any) -> None:
         """Locate the vacuum cleaner."""
         await self.coordinator.async_send_command(
-            build_command("find_robot", active=True)
+            build_command(
+                "find_robot",
+                api_type=self.coordinator.data.api_type,
+                active=True,
+            )
         )
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
@@ -452,7 +481,11 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
             raise ValueError(f"Fan speed {fan_speed} not supported")
 
         await self.coordinator.async_send_command(
-            build_command("set_fan_speed", fan_speed=fan_speed)
+            build_command(
+                "set_fan_speed",
+                api_type=self.coordinator.data.api_type,
+                fan_speed=fan_speed,
+            )
         )
 
     async def async_get_segments(self) -> list[Segment]:

--- a/custom_components/robovac_mqtt/vacuum.py
+++ b/custom_components/robovac_mqtt/vacuum.py
@@ -463,7 +463,9 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
 
     async def async_clean_spot(self, **kwargs: Any) -> None:
         """Perform a spot clean-up."""
-        await self.coordinator.async_send_command(build_command("clean_spot"))
+        await self.coordinator.async_send_command(
+            build_command("clean_spot", api_type=self._api_type)
+        )
 
     async def async_locate(self, **kwargs: Any) -> None:
         """Locate the vacuum cleaner."""
@@ -562,6 +564,10 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
         if isinstance(params, dict):
             command_kwargs.update(params)
         command_kwargs.update(kwargs)
+        # Route raw service commands through the device's DPS protocol too, so
+        # e.g. vacuum.send_command "pause" emits a scalar write on scalar
+        # (Tuya) devices. An explicit api_type in params still wins.
+        command_kwargs.setdefault("api_type", self._api_type)
 
         command_dict = build_command(command, **command_kwargs)
         if command_dict:

--- a/docs/g50_capture/FINDINGS.md
+++ b/docs/g50_capture/FINDINGS.md
@@ -1,0 +1,233 @@
+# G50 (T2210) DPS capture findings
+
+Captured live 2026-06-02 against real robot via Docker dev HA. Robot idle/charging on socket.
+
+## Baseline (idle, charging, ~99%)
+
+| DPS | Value | Meaning (hypothesis) | Form |
+|---|---|---|---|
+| 102 | 1 | **Suction** (0=Quiet,1=Standard,2=Turbo,3=Max) | int scalar |
+| 104 | 99 | **Battery %** (app ~100% on charge) | int scalar |
+| 107 | `{"en":true,"start_t":"2200","end_t":"0800"}` | **DND** (en + HHMM strings) | JSON |
+| 150 | `{"side_brush":6209,"roller_brush":6209,"dust_filter":6209,"mop":0,"roller_brush_cover":6208,"sensors":1355}` | accessory usage counters | JSON |
+| 151 | `{"l":[{"e":true,"t":"1400","r":"246","s":2,"f":2,"id":...}]}` | schedule | JSON |
+| 154 | 2 | clean-type / mode? (NOT suction) | int scalar |
+| 177 | (scalar) | error code | int scalar |
+| 109 | 960 | clean stats? | int |
+| 110 | 16 | clean stats? | int |
+| 111 | 9 | clean stats? | int |
+| 138 | 2 | ? | int |
+| 135 | 1 | ? | int |
+| 170 | `ctg_set_mode2:0` | ? | string |
+| 127 | `{"status":"O","cid":551,"sid":551,"version":10}` | ? | JSON |
+| 1,2,3,5,15,103,106,108,118,122,136,137,139,142,155,161 | misc | unknown scalars | int/None |
+
+## Confirmed mappings
+
+### Suction = DPS 102 ✅
+Toggled Quiet→Standard→Turbo→Max, DPS 102 = 0→1→2→3. Plain int.
+Scale: `0=Quiet, 1=Standard, 2=Turbo, 3=Max`.
+
+### BoostIQ = DPS 118 ✅
+Toggled off→on, DPS 118 = 0→1. Plain int bool. `0=off, 1=on`.
+
+### Cleaning Mode (path pattern) = DPS 154 ✅
+Toggled Arranged→Random→Arranged→Random, DPS 154 = 1→2→1→2. Plain int.
+Scale: `1=Arranged, 2=Random`. NOTE: on X10 this DPS is base64 protobuf CleanParam —
+on G50 it's a bare int. This is the core decode mismatch.
+
+### Battery = DPS 104 (strong) ✅
+Observed 99→98 drifting live while idle on charge. Plain int %.
+
+### DND = DPS 107 ✅
+Toggled off→on, then times to 2100-0900. DPS 107 JSON:
+`{"en": bool, "start_t": "HHMM", "end_t": "HHMM"}`.
+
+### Child Lock = DPS 139 ✅
+Toggled on→off, DPS 139 = 1→0. Plain int bool. `0=off, 1=on`. Baseline 0.
+
+## Summary — G50 target map (all scalar/JSON, NO protobuf)
+
+| Feature | DPS | Form | Scale / shape |
+|---|---|---|---|
+| Battery % | 104 | int | 0-100 |
+| Suction | 102 | int | 0=Quiet 1=Standard 2=Turbo 3=Max |
+| BoostIQ | 118 | int bool | 0/1 |
+| Cleaning mode (path) | 154 | int | 1=Arranged 2=Random |
+| DND | 107 | JSON | {en:bool, start_t:"HHMM", end_t:"HHMM"} |
+| Child lock | 139 | int bool | 0/1 |
+| Accessories | 150 | JSON | usage counters (see below) |
+| Error code | 177 | int | scalar (NOT protobuf on G50) |
+
+### Auto-Return Cleaning = DPS 135 ✅ (app "Cleaning Preference" section)
+Toggled off→on, DPS 135 = 0→1. Plain int bool. Canonical Tuya `auto_return`
+("when battery low, return to dock; resume at 80%"). Entity named "Auto-Return
+Cleaning".
+
+### Accessory reset = DPS 150 JSON {<key>: 0} ✅ (captured via /req; HA verified)
+App reset sends e.g. {"150": "{\"sensors\":0}"}. Reset any accessory by writing
+DPS 150 with that field zeroed: dust_filter / roller_brush / side_brush / sensors.
+Verified live: HA "Reset Side Brush" -> app shows 100% after refresh.
+
+### *** Accessory calibration SOLVED (app data 2026-06-02) ***
+Counters in DPS 150 are MINUTES USED. Per-accessory MAX LIFE (hours), from app:
+| Accessory | DPS150 key | counter(min) | max(h) | calc remaining | app |
+|---|---|---|---|---|---|
+| Sensors | sensors | 1355 | 35 | 12.4h / 37% | 13h / 37% ✓ |
+| Filter | dust_filter | 6209 | 200 | 96.5h / 48% | 94h / 48% ✓ |
+| Side brush | side_brush | 6209 | 250 | 146.5h / 58% | 147h / 58% ✓ |
+| Rolling brush | roller_brush | 6209 | 360 | 256.5h / 71% | 257h / 71% ✓ |
+% remaining = 1 − used_min / (max_h*60). G50 maxes (35/200/250/360h) DIFFER from
+X-series ACCESSORY_MAX_LIFE. Need a G_SERIES_ACCESSORY_MAX_LIFE dict (hours).
+roller_brush_cover (6208) = "Brush Guard" (no fixed life, replace 3-6mo). mop=0 (N/A).
+
+### Volume = DPS 111 ✅
+Toggled muted/20/70/100/50%, DPS 111 = 0/2/7/10/5. Scale 0-10 = 0-100% in 10% steps.
+Baseline 9 = 90% (matched app). New entity opportunity (number/select).
+
+### Language / voice pack (low priority, NOT a target feature)
+Language change (English↔Deutsch) did not emit a clear scalar in-window (likely emits
+on voice-pack download complete). DPS 127 `{"status":"O"→"F",...,"cid":551}` appears to
+track the voice-pack download job. Leave unmapped.
+
+### Activity Log Upload = DPS 142 ✅ (diagnostic, low priority)
+Toggled on→off, DPS 142 = 1→0. Plain int bool. Baseline 0.
+
+### Find My Robot = DPS 103 ✅
+Start→Stop, DPS 103 = 1→0. Plain int bool. Baseline 0.
+NOTE: X10 FIND_ROBOT = DPS 160. G50 uses 103. Plan said find_robot "works" — verify
+the existing switch actually drives 103 on G50, not 160.
+
+### *** WORK STATE = DPS 15 — CONFIRMED end-to-end ***
+**The G50 sends NO DPS 153 (WorkStatus protobuf) at all.** X10 derives activity from
+the WorkStatus proto on 153; G50 has none. State lives in scalar **DPS 15** (+ DPS 5
+task flag). Confirmed via a CLEAN run from main screen (no manual pad):
+Start→cleaning, Pause→paused, Recharge→returning, dock→charging.
+
+| DPS 15 | Activity | Evidence |
+|---|---|---|
+| 0, 1 | idle/standby | baseline; after task end |
+| 2 | cleaning (active) | auto-clean, stable 15=2/5=1 (no manual pad) |
+| 4 | returning (go home) | pressed Recharge → 15=4/5=3 |
+| 5 | docked/charging | reached dock, "Charging" → 15=5, 5→0 |
+| 7 | paused (resumable) | pressed Pause → 15=7/5=1; also manual-pad idle-between-presses |
+
+| DPS 5 | Task flag |
+|---|---|
+| 0 | no task / idle |
+| 1 | active cleaning |
+| 3 | returning |
+| 2 | paused (seen run 1) |
+
+GOTCHA: the manual-control screen puts the robot in repeated press-to-move, so DPS 15
+flaps 2↔7 there (moving vs paused-between-presses). Ignore manual-pad data for the
+state map — the clean main-screen run above is authoritative.
+DPS 2 = movement/active echo (toggles 0/1 during motion), not state.
+
+Charging boolean (binary_sensor.g50_charging) = (DPS 15 == 5).
+This means the vacuum entity's activity mapping needs a G-series path too (bigger than
+the original plan, which assumed state already worked).
+
+### Battery = DPS 104 CONFIRMED ✅
+Read 86 at dock; app showed 86%. Direct % int.
+
+### Find My Robot (manual screen) confirmed DPS 103 (see above).
+
+### Clean stats: DPS 109 / 110 — VERIFIED against TWO live runs + app history
+- **DPS 109 = cleaning TIME (seconds)**: run1 300 → app 5 min; run2 780 → app 13 min.
+- **DPS 110 = cleaning AREA (m²)**: run1 4 → app 43 ft²; run2 3 → app 32 ft².
+(Initially mapped backwards from a single run; the 2nd run — 11 min in a small
+bathroom, 109 climbing to 780 while 110 stuck at 3 — exposed the swap, and the
+app history "32 ft² | 13 min" confirmed it.) cleaning_time uses 109 as-is (seconds),
+cleaning_area uses 110 (m²). Error 7002 ("MACHINE PICKED UP") verified on DPS 106
+this session by lifting the robot.
+
+### Detangle roller brush = {"153": 1} ✅ (captured via /req; HA button verified)
+Write DPS 153 = 1 starts roller-brush detangle. (153 reads as 0 in /res — it's a
+write-only command DP on the G50, distinct from its X-series WORK_STATUS meaning.)
+Exposed as a "Detangle Roller Brush" button, gated to scalar devices.
+
+### (historical) Detangle roller brush — earlier thought NOT capturable via /res
+Pressed twice; ran loudly both times; ZERO change in any received DPS (stayed 15=5/5=0
+docked). We only subscribe to the device `/res` state topic, never the app→device `/req`
+command topic. One-shot maintenance actions (detangle, and likely empty/wash/dry on
+other models) leave no persistent state bit → invisible to capture. Implement as a
+BUTTON entity sending an outbound command, derived by analogy with api/commands.py +
+verified by live write-test. Cannot be reverse-engineered from this capture method.
+
+### Ecosystem research + architecture decisions (2026-06-02)
+- The G50 scalar DPS ARE the canonical **Tuya** robovac schema (validated vs
+  `damacus/robovac` which has a `T2210.py`="G50"). Confirmed names: 102=fan_speed,
+  103=locate, 104=battery, 107=do_not_disturb, 118=boost_iq, 5=mode, 15=status.
+  Canonical also says: 2=start_pause, 3=direction, 101=return_home, 106=error_code.
+- **Movement commands (validated, not yet live-tested):** start/pause=DPS 2,
+  return_home=DPS 101, direction=DPS 3, mode=DPS 5.
+- **Re-verify:** our error DPS (177) vs canonical 106; 135 we called "cleaning
+  preference" but canonical = auto_return; suction labels (app showed Quiet/Std/
+  Turbo/Max — empirical wins for T2210, but canonical-G is Std/Turbo/Max/Boost_IQ).
+- **PR #110** (jeppesens, OPEN) adds a Tuya-CLOUD "legacy" layer (string DPS 15,
+  cloud transport) with `api_type` "novel"/"legacy" dispatch. The G50 is a THIRD
+  variant: Tuya scalar (INT) over MQTT. We mirror #110's naming/structure but keep
+  our own value-shape path. #110's key-presence checkApiType would MISCLASSIFY the
+  G50 as novel (G50 reuses DPS 153/154/155/160/177 numbers with scalar values) —
+  so we detect by VALUE SHAPE instead (DPS 153/154 int-not-base64 -> scalar).
+- **PR base = jeppesens/main** (martijnpoppen is a different TS/Homey codebase).
+- DESIGN (implemented): `VacuumState.api_type` ("novel"/"scalar"/"legacy"),
+  classified cloud-side by `EufyLogin.checkApiType(dps)` and seeded by the
+  coordinator at init. const G_SERIES_* renamed SCALAR_*. Entities/commands gate
+  on api_type, not model. No model hardcoding.
+- ALIGNMENT: `main` already had `checkApiType` + a per-device `apiType` field
+  (dormant #110 groundwork, unconsumed) but its key-presence check MISCLASSIFIED
+  the G50 as "novel" (G50 carries protobuf DPS *numbers* 153/154 with int values).
+  We fixed `checkApiType` to be value-shape based (returns novel/scalar/legacy via
+  utils.is_protobuf_dps_value) and wired its `apiType` through the coordinator —
+  reusing the maintainer's mechanism instead of a parallel one. Pionaur's C28
+  (T211A) fork work is a protobuf device + findModel MQTT fallback; no overlap.
+
+### Outbound commands — live-tested results (2026-06-02)
+WORKING (verified via /req send + /res echo on real robot):
+- Suction (102), BoostIQ (118), Child lock (139), Cleaning pattern (154),
+  Volume (111), DND (107 JSON). All scalar writes; robot echoes new value.
+MOVEMENT — SOLVED ✅ (captured from the app's own /req, then verified from HA):
+- **start/clean = {"5": 1}** (DPS 5 work-mode = 1)
+- **go home = {"5": 3}** (DPS 5 work-mode = 3)
+- **pause = {"122": 1}**
+- **resume = {"122": 2}**  (NOT 0 — DPS 122 is multi-valued: 1=pause, 2=resume)
+- All four verified live from the HA UI (robot physically started/paused/resumed/
+  returned). DPS 2 (Tuya START_PAUSE) and DPS 101 (RETURN_HOME) are ACKed but
+  IGNORED by G50 firmware — the app drives DPS 5 + 122 instead.
+- METHOD THAT CRACKED IT: temporarily subscribed the MQTT client to the device's
+  /req topic (where the app publishes) and read the app's exact command payloads.
+  Non-destructive. (Reverted after capture — do not ship the /req subscription.)
+- DPS 122 also a /res motion flag (1=stationary). Parser maps 122==1 while
+  mid-clean -> activity "paused" so HA reflects pause + offers resume.
+- EARLIER GOTCHA (resolved): blind DPS-2 attempts had left the Anker cloud/app on
+  a stale "Home Clean" state; using the app's real commands behaves cleanly.
+
+### CAPTURE METHOD LIMITS (important for future sessions)
+- Robot pushes FULL DPS dumps periodically (~every 70-84s when idle), plus an immediate
+  dump on most state-changing settings toggles. On-change is reliable for persistent
+  settings; transient/one-shot actions can be missed between periodic dumps.
+- We see ONLY `/res` (device→cloud state). Outbound commands (`/req`) are not observable
+  here → command formats must be derived from code + confirmed by write-test.
+
+### Schedule = DPS 151 JSON (partial)
+Emits on Save. Structure: `{"l":[ {entry}, ... ]}`, each entry:
+`{"e":bool enabled, "t":"HHMM", "r":"<days>", "s":suction 0-3, "f":pattern 1=Arranged/2=Random, "id":unix-ts}`
+Confirmed: t (0930=09:30), s (0=Quiet, matches DPS 102 scale), f (1/2 matches DPS 154), e, id.
+`r` = SOLVED: concatenated string of day DIGITS, 1=Mon..7=Sun (NOT a bitmask).
+  "15"=Mon+Fri, "246"=Tue+Thu+Sat, "134567"=all-but-Tuesday. Verified across 3 saves.
+Note: app shows "timed out" on save but device DOES receive it (/res confirms) — app
+cloud-ack timeout only, cosmetic.
+
+### Unknown scalars still unmapped (low priority)
+Unmapped: **108, 136, 137, 138, 170**. (Everything else observed is in `SCALAR_DPS`.)
+- Not in any public Tuya schema: `damacus/robovac`'s `T2210` maps only the basics
+  (2,3,5,15,101,102,103,104,106); its base `RobovacCommand` enum is string-keyed with
+  no numeric for these.
+- `170="ctg_set_mode2:0"` is a command-channel echo (`ctg` = category, `set_mode2`),
+  tied to a settings write, not a state — nothing to surface.
+- `108, 136, 137, 138` had no observed app control to diff against during capture
+  (136/137 sit beside 135/139, so likely sibling setting toggles; 138 read a stable 2).
+- Mapping any of these needs another live capture toggling the specific app control
+  that drives them. Low value (no user-facing feature gated on them) — left unmapped.

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -20,6 +20,7 @@ def mock_coordinator():
     coordinator.device_id = "test_id"
     coordinator.device_name = "Test Vac"
     coordinator.device_model = "T2118"
+    coordinator.api_type = "novel"
     coordinator.data = VacuumState()
     coordinator.async_send_command = AsyncMock()
     return coordinator
@@ -46,7 +47,7 @@ async def test_button_press(mock_coordinator):
 
         await entity.async_press()
 
-        mock_build.assert_called_with("collect_dust")
+        mock_build.assert_called_with("collect_dust", api_type="novel")
         mock_coordinator.async_send_command.assert_called_with({"cmd": "collect"})
 
 
@@ -68,6 +69,8 @@ async def test_button_reset_accessory(mock_coordinator):
         await entity.async_press()
 
         mock_build.assert_called_with(
-            "reset_accessory", reset_type=ConsumableRequest.FILTER_MESH
+            "reset_accessory",
+            api_type="novel",
+            reset_type=ConsumableRequest.FILTER_MESH,
         )
         mock_coordinator.async_send_command.assert_called_with({"cmd": "reset"})

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -56,6 +56,24 @@ def test_check_api_type_legacy():
     assert EufyLogin.checkApiType({"999": "value"}) == "legacy"
 
 
+def test_check_api_type_scalar():
+    """Scalar (Tuya, e.g. G50) devices reuse protobuf DPS numbers with int values.
+
+    A key-presence check would misclassify these as 'novel'; value-shape
+    classification must return 'scalar'.
+    """
+    # Real G50 snapshot shape: 153/154 present as plain ints
+    assert EufyLogin.checkApiType({"153": 0, "154": 2, "104": 86}) == "scalar"
+    # 154 int alone
+    assert EufyLogin.checkApiType({"154": 2}) == "scalar"
+    # Numeric strings are scalar too
+    assert EufyLogin.checkApiType({"154": "2"}) == "scalar"
+    # Scalar-only state DPS 15 is a positive signal
+    assert EufyLogin.checkApiType({"15": 5}) == "scalar"
+    # Genuine protobuf base64 stays novel even alongside scalar-looking keys
+    assert EufyLogin.checkApiType({"153": "CgYIBRABGAU="}) == "novel"
+
+
 def test_find_model_found():
     """findModel returns device info with invalid=False for a known device."""
     login = _make_login(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -98,9 +98,9 @@ def test_g_series_commands_via_dispatch():
 def test_scalar_movement_commands():
     """G50 movement (captured from the app's /req): start/home via DPS 5,
     pause/resume via DPS 122. (DPS 2/101 are ignored by the firmware.)"""
-    from custom_components.robovac_mqtt.const import SCALAR_DPS
-
-    assert build_command("start_auto", api_type="scalar") == {SCALAR_DPS["WORK_MODE"]: 1}
+    assert build_command("start_auto", api_type="scalar") == {
+        SCALAR_DPS["WORK_MODE"]: 1
+    }
     assert build_command("return_to_base", api_type="scalar") == {
         SCALAR_DPS["WORK_MODE"]: 3
     }

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,12 +2,15 @@
 
 from custom_components.robovac_mqtt.api.commands import (
     build_command,
+    build_set_boost_iq_command,
     build_set_child_lock_command,
     build_set_cleaning_intensity_command,
     build_set_cleaning_mode_command,
+    build_set_cleaning_pattern_command,
+    build_set_volume_command,
     build_set_water_level_command,
 )
-from custom_components.robovac_mqtt.const import DPS_MAP
+from custom_components.robovac_mqtt.const import DPS_MAP, SCALAR_DPS
 from custom_components.robovac_mqtt.proto.cloud.unisetting_pb2 import UnisettingRequest
 from custom_components.robovac_mqtt.utils import decode
 
@@ -42,3 +45,71 @@ def test_set_child_lock_command():
     assert DPS_MAP["UNSETTING"] in result
     decoded = decode(UnisettingRequest, result[DPS_MAP["UNSETTING"]])
     assert decoded.children_lock.value is True
+
+
+# ── G-series scalar command builders (T2210/G50) ─────────────────────
+
+
+def test_set_boost_iq_command():
+    """BoostIQ writes a plain int to DPS 118."""
+    assert build_set_boost_iq_command(True) == {SCALAR_DPS["BOOST_IQ"]: 1}
+    assert build_set_boost_iq_command(False) == {SCALAR_DPS["BOOST_IQ"]: 0}
+
+
+def test_set_cleaning_pattern_command():
+    """Cleaning pattern maps Arranged->1, Random->2 on DPS 154."""
+    assert build_set_cleaning_pattern_command("Arranged") == {
+        SCALAR_DPS["CLEAN_PATTERN"]: 1
+    }
+    assert build_set_cleaning_pattern_command("Random") == {
+        SCALAR_DPS["CLEAN_PATTERN"]: 2
+    }
+
+
+def test_set_volume_command():
+    """Volume percent maps to a 0-10 step on DPS 111."""
+    assert build_set_volume_command(0) == {SCALAR_DPS["VOLUME"]: 0}
+    assert build_set_volume_command(50) == {SCALAR_DPS["VOLUME"]: 5}
+    assert build_set_volume_command(100) == {SCALAR_DPS["VOLUME"]: 10}
+    # Out-of-range clamps
+    assert build_set_volume_command(140) == {SCALAR_DPS["VOLUME"]: 10}
+
+
+def test_g_series_commands_via_dispatch():
+    """build_command dispatches the G-series command names."""
+    assert build_command("set_boost_iq", active=True) == {SCALAR_DPS["BOOST_IQ"]: 1}
+    assert build_command("set_cleaning_pattern", pattern="Random") == {
+        SCALAR_DPS["CLEAN_PATTERN"]: 2
+    }
+    assert build_command("set_volume", volume=70) == {SCALAR_DPS["VOLUME"]: 7}
+    assert build_command("set_auto_return", active=True) == {
+        SCALAR_DPS["AUTO_RETURN"]: 1
+    }
+    assert build_command("set_activity_log", active=False) == {
+        SCALAR_DPS["ACTIVITY_LOG"]: 0
+    }
+    assert build_command("detangle_brush") == {SCALAR_DPS["DETANGLE"]: 1}
+    # Accessory reset = DPS 150 JSON with the counter zeroed
+    assert build_command(
+        "reset_accessory", api_type="scalar", scalar_key="sensors"
+    ) == {SCALAR_DPS["ACCESSORIES"]: '{"sensors": 0}'}
+
+
+def test_scalar_movement_commands():
+    """G50 movement (captured from the app's /req): start/home via DPS 5,
+    pause/resume via DPS 122. (DPS 2/101 are ignored by the firmware.)"""
+    from custom_components.robovac_mqtt.const import SCALAR_DPS
+
+    assert build_command("start_auto", api_type="scalar") == {SCALAR_DPS["WORK_MODE"]: 1}
+    assert build_command("return_to_base", api_type="scalar") == {
+        SCALAR_DPS["WORK_MODE"]: 3
+    }
+    assert build_command("pause", api_type="scalar") == {SCALAR_DPS["PAUSE"]: 1}
+    assert build_command("stop", api_type="scalar") == {SCALAR_DPS["PAUSE"]: 1}
+    assert build_command("play", api_type="scalar") == {SCALAR_DPS["PAUSE"]: 2}
+    # Novel devices still get protobuf movement payloads (unchanged)
+    assert build_command("start_auto", api_type="novel") != {SCALAR_DPS["WORK_MODE"]: 1}
+    # Scalar SETTINGS remain real scalar writes (unaffected)
+    assert build_command("set_fan_speed", api_type="scalar", fan_speed="Max") == {
+        "102": 3
+    }

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,0 +1,59 @@
+"""Unit tests for entity.py: protocol capability gating."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.robovac_mqtt.entity import (
+    effective_api_type,
+    filter_supported_entities,
+)
+
+
+@pytest.mark.parametrize(
+    ("api_type", "expected"),
+    [
+        ("scalar", "scalar"),
+        ("novel", "novel"),
+        ("legacy", "novel"),
+        ("unknown", "novel"),
+        ("", "novel"),
+    ],
+)
+def test_effective_api_type(api_type, expected):
+    """Any non-scalar api type speaks the novel protocol."""
+    assert effective_api_type(api_type) == expected
+
+
+def _entity(supported):
+    entity = MagicMock()
+    entity.supported_api_types = supported
+    return entity
+
+
+@pytest.mark.parametrize(
+    ("api_type", "expected_supported"),
+    [
+        ("novel", [None, ("novel",)]),
+        ("scalar", [None, ("scalar",)]),
+        ("legacy", [None, ("novel",)]),  # legacy/unknown parse+command as novel
+    ],
+)
+def test_filter_supported_entities(api_type, expected_supported):
+    """Only universal + matching-protocol entities survive the filter."""
+    coordinator = MagicMock()
+    coordinator.api_type = api_type
+    entities = [_entity(None), _entity(("novel",)), _entity(("scalar",))]
+
+    result = filter_supported_entities(coordinator, entities)
+
+    assert [e.supported_api_types for e in result] == expected_supported
+
+
+def test_filter_supported_entities_missing_attribute_is_universal():
+    """Entities that never declare supported_api_types are kept everywhere."""
+    coordinator = MagicMock()
+    coordinator.api_type = "scalar"
+    entity = object()  # no supported_api_types attribute at all
+
+    assert filter_supported_entities(coordinator, [entity]) == [entity]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,6 +9,7 @@ from custom_components.robovac_mqtt.api.parser import (
     _map_work_status,
     _parse_map_data,
     _process_cleaning_parameters,
+    update_state,
 )
 from custom_components.robovac_mqtt.const import WORK_MODE_NAMES
 from custom_components.robovac_mqtt.models import VacuumState
@@ -509,8 +510,6 @@ _G50_DPS = {
 
 
 def _parse_g50(dps):
-    from custom_components.robovac_mqtt.api.parser import update_state
-
     # api_type is sticky in real use (set from the first full message); set it
     # here so partial-dps cases route to the scalar parser deterministically.
     state = VacuumState(device_model="T2210", api_type="scalar")
@@ -624,8 +623,6 @@ def test_g_series_accepts_string_scalars():
 
 def test_scalar_pause_flag_marks_paused():
     """DPS 122=1 while mid-clean -> paused; 122=0 -> back to cleaning."""
-    from custom_components.robovac_mqtt.api.parser import update_state
-
     s = VacuumState(device_model="T2210", api_type="scalar")
     s, _ = update_state(s, {"15": 2})  # cleaning
     assert s.activity == "cleaning"
@@ -642,8 +639,6 @@ def test_scalar_pause_flag_marks_paused():
 
 def test_novel_state_ignores_scalar_dps():
     """A novel (protobuf) state must NOT interpret scalar DPS numbers as state."""
-    from custom_components.robovac_mqtt.api.parser import update_state
-
     state = VacuumState(api_type="novel")
     new_state, _ = update_state(state, {"104": 86, "102": 0})
     # Novel path ignores Tuya scalar keys -> defaults preserved

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -477,3 +477,178 @@ def test_work_mode_names_mapping():
     assert WORK_MODE_NAMES[1] == "Room"
     assert WORK_MODE_NAMES[3] == "Spot"
     assert WORK_MODE_NAMES[8] == "Scene"
+
+
+# ── G-series scalar/JSON protocol (e.g. T2210/G50) ───────────────────
+# These devices send plain int/JSON DPS on different DPS numbers and emit no
+# WorkStatus (153). Captured from a real G50 — see docs/g50_capture/FINDINGS.md.
+
+_G50_DPS = {
+    "15": 5,  # state -> docked/charging
+    "5": 0,
+    "104": 86,  # battery
+    "102": 0,  # suction -> Quiet
+    "118": 1,  # BoostIQ on
+    "154": 2,  # pattern -> Random
+    "111": 5,  # volume -> 50%
+    "139": 0,  # child lock off
+    "103": 0,  # find robot off
+    "107": {"en": True, "start_t": "2100", "end_t": "0900"},  # DND
+    "150": {  # accessory usage counters (minutes)
+        "side_brush": 6209,
+        "roller_brush": 6209,
+        "dust_filter": 6209,
+        "mop": 0,
+        "roller_brush_cover": 6208,
+        "sensors": 1355,
+    },
+    "109": 300,  # clean time = 300 s (5 min)
+    "110": 4,  # clean area = 4 m² (≈43 ft²)
+    "177": 0,  # error code (scalar, not protobuf)
+}
+
+
+def _parse_g50(dps):
+    from custom_components.robovac_mqtt.api.parser import update_state
+
+    # api_type is sticky in real use (set from the first full message); set it
+    # here so partial-dps cases route to the scalar parser deterministically.
+    state = VacuumState(device_model="T2210", api_type="scalar")
+    new_state, _ = update_state(state, dps)
+    return new_state
+
+
+def test_g_series_state_and_battery():
+    s = _parse_g50(_G50_DPS)
+    assert s.activity == "docked"
+    assert s.charging is True
+    assert s.task_status == "Charging"
+    assert s.battery_level == 86
+
+
+def test_g_series_state_transitions():
+    assert _parse_g50({"15": 2}).activity == "cleaning"
+    assert _parse_g50({"15": 4}).activity == "returning"
+    assert _parse_g50({"15": 7}).activity == "paused"
+    assert _parse_g50({"15": 0}).activity == "idle"
+    assert _parse_g50({"15": 5}).activity == "docked"  # charging
+    assert _parse_g50({"15": 6}).activity == "docked"  # charge complete
+    assert _parse_g50({"15": 5}).charging is True
+    assert _parse_g50({"15": 6}).charging is False
+    assert _parse_g50({"15": 2}).charging is False
+
+
+def test_g_series_suction_scale():
+    assert _parse_g50({"102": 0}).fan_speed == "Quiet"
+    assert _parse_g50({"102": 1}).fan_speed == "Standard"
+    assert _parse_g50({"102": 2}).fan_speed == "Turbo"
+    assert _parse_g50({"102": 3}).fan_speed == "Max"
+
+
+def test_g_series_toggles_and_pattern():
+    s = _parse_g50(_G50_DPS)
+    assert s.boost_iq is True
+    assert s.cleaning_pattern == "Random"
+    assert _parse_g50({"154": 1}).cleaning_pattern == "Arranged"
+    assert s.volume == 50
+    assert s.child_lock is False
+    assert s.find_robot is False
+
+
+def test_g_series_dnd_json():
+    s = _parse_g50(_G50_DPS)
+    assert s.dnd_enabled is True
+    assert (s.dnd_start_hour, s.dnd_start_minute) == (21, 0)
+    assert (s.dnd_end_hour, s.dnd_end_minute) == (9, 0)
+
+
+def test_g_series_accessories_counters():
+    s = _parse_g50(_G50_DPS)
+    assert s.accessories.filter_usage == 6209
+    assert s.accessories.main_brush_usage == 6209
+    assert s.accessories.side_brush_usage == 6209
+    assert s.accessories.sensor_usage == 1355
+
+
+def test_scalar_clean_stats():
+    """DPS 109 = cleaning time (seconds), DPS 110 = cleaning area (m²).
+    Verified live: 300s/4m² -> app 5min/43ft²; 780s/3m² -> app 13min/32ft²."""
+    s = _parse_g50({"109": 300, "110": 4})
+    assert s.cleaning_time == 300
+    assert s.cleaning_area == 4
+    s = _parse_g50({"109": 780, "110": 3})
+    assert s.cleaning_time == 780
+    assert s.cleaning_area == 3
+
+
+def test_scalar_cleaning_pref_and_activity_log():
+    assert _parse_g50({"135": 1}).auto_return is True
+    assert _parse_g50({"135": 0}).auto_return is False
+    assert _parse_g50({"142": 1}).activity_log_upload is True
+    assert _parse_g50({"142": 0}).activity_log_upload is False
+
+
+def test_scalar_error_from_106_and_177():
+    assert _parse_g50({"106": 5}).error_code == 5
+    assert _parse_g50({"177": 7}).error_code == 7
+    assert _parse_g50({"106": 0, "177": 0}).error_code == 0
+    assert _parse_g50({"106": 0, "177": 0}).error_message == ""
+    # non-zero fault wins regardless of which key carries it
+    assert _parse_g50({"106": 0, "177": 9}).error_code == 9
+    # 4-digit codes map via EUFY_CLEAN_ERROR_CODES (verified live: 7002 lift fault)
+    s = _parse_g50({"106": 7002})
+    assert s.error_code == 7002
+    assert s.error_message == "MACHINE PICKED UP"
+
+
+def test_scalar_schedule_decode():
+    s = _parse_g50(
+        {"151": {"l": [{"e": True, "t": "0930", "r": "246", "s": 0, "f": 1, "id": 1}]}}
+    )
+    assert len(s.schedules) == 1
+    e = s.schedules[0]
+    assert e["enabled"] is True
+    assert e["time"] == "09:30"
+    assert e["days"] == "Tue, Thu, Sat"
+    assert e["suction"] == "Quiet"
+    assert e["pattern"] == "Arranged"
+
+
+def test_g_series_accepts_string_scalars():
+    """Device sometimes sends scalars as strings; parser must coerce."""
+    s = _parse_g50({"104": "73", "102": "2", "15": "2"})
+    assert s.battery_level == 73
+    assert s.fan_speed == "Turbo"
+    assert s.activity == "cleaning"
+
+
+def test_scalar_pause_flag_marks_paused():
+    """DPS 122=1 while mid-clean -> paused; 122=0 -> back to cleaning."""
+    from custom_components.robovac_mqtt.api.parser import update_state
+
+    s = VacuumState(device_model="T2210", api_type="scalar")
+    s, _ = update_state(s, {"15": 2})  # cleaning
+    assert s.activity == "cleaning"
+    s, _ = update_state(s, {"122": 1})  # stationary mid-clean -> paused
+    assert s.activity == "paused"
+    assert s.task_status == "Paused"
+    s, _ = update_state(s, {"122": 0, "15": 2})  # moving again
+    assert s.activity == "cleaning"
+    # 122=1 while docked must NOT be read as paused
+    d = VacuumState(device_model="T2210", api_type="scalar")
+    d, _ = update_state(d, {"15": 5, "122": 1})
+    assert d.activity == "docked"
+
+
+def test_novel_state_ignores_scalar_dps():
+    """A novel (protobuf) state must NOT interpret scalar DPS numbers as state."""
+    from custom_components.robovac_mqtt.api.parser import update_state
+
+    state = VacuumState(api_type="novel")
+    new_state, _ = update_state(state, {"104": 86, "102": 0})
+    # Novel path ignores Tuya scalar keys -> defaults preserved
+    assert new_state.battery_level == 0
+    assert new_state.activity == "idle"
+
+
+# Protocol classification (checkApiType) is tested in tests/test_cloud.py.

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -204,7 +204,9 @@ async def test_cleaning_mode_select_entity(mock_coordinator):
 
         await entity.async_select_option("Mop")
 
-        mock_build.assert_called_with("set_cleaning_mode", clean_mode="Mop")
+        mock_build.assert_called_with(
+            "set_cleaning_mode", api_type=mock_coordinator.data.api_type, clean_mode="Mop"
+        )
         mock_coordinator.async_send_command.assert_called_with(
             {"cmd": "clean_mode_cmd"}
         )
@@ -225,7 +227,9 @@ async def test_water_level_select_entity(mock_coordinator):
 
         await entity.async_select_option("High")
 
-        mock_build.assert_called_with("set_water_level", water_level="High")
+        mock_build.assert_called_with(
+            "set_water_level", api_type=mock_coordinator.data.api_type, water_level="High"
+        )
         mock_coordinator.async_send_command.assert_called_with(
             {"cmd": "water_level_cmd"}
         )
@@ -247,7 +251,7 @@ async def test_cleaning_intensity_select_entity(mock_coordinator):
         await entity.async_select_option("Quick")
 
         mock_build.assert_called_with(
-            "set_cleaning_intensity", cleaning_intensity="Quick"
+            "set_cleaning_intensity", api_type=mock_coordinator.data.api_type, cleaning_intensity="Quick"
         )
         mock_coordinator.async_send_command.assert_called_with(
             {"cmd": "clean_intensity_cmd"}
@@ -295,7 +299,9 @@ async def test_mop_intensity_select_entity_async(mock_coordinator):
         await entity.async_select_option("Max")
 
         # Should map "Max" to "High" for the device command
-        mock_build.assert_called_with("set_water_level", water_level="High")
+        mock_build.assert_called_with(
+            "set_water_level", api_type=mock_coordinator.data.api_type, water_level="High"
+        )
         mock_coordinator.async_send_command.assert_called_with(
             {"cmd": "water_level_cmd"}
         )

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -205,7 +205,9 @@ async def test_cleaning_mode_select_entity(mock_coordinator):
         await entity.async_select_option("Mop")
 
         mock_build.assert_called_with(
-            "set_cleaning_mode", api_type=mock_coordinator.data.api_type, clean_mode="Mop"
+            "set_cleaning_mode",
+            api_type=mock_coordinator.data.api_type,
+            clean_mode="Mop",
         )
         mock_coordinator.async_send_command.assert_called_with(
             {"cmd": "clean_mode_cmd"}
@@ -228,7 +230,9 @@ async def test_water_level_select_entity(mock_coordinator):
         await entity.async_select_option("High")
 
         mock_build.assert_called_with(
-            "set_water_level", api_type=mock_coordinator.data.api_type, water_level="High"
+            "set_water_level",
+            api_type=mock_coordinator.data.api_type,
+            water_level="High",
         )
         mock_coordinator.async_send_command.assert_called_with(
             {"cmd": "water_level_cmd"}
@@ -251,7 +255,9 @@ async def test_cleaning_intensity_select_entity(mock_coordinator):
         await entity.async_select_option("Quick")
 
         mock_build.assert_called_with(
-            "set_cleaning_intensity", api_type=mock_coordinator.data.api_type, cleaning_intensity="Quick"
+            "set_cleaning_intensity",
+            api_type=mock_coordinator.data.api_type,
+            cleaning_intensity="Quick",
         )
         mock_coordinator.async_send_command.assert_called_with(
             {"cmd": "clean_intensity_cmd"}
@@ -300,7 +306,9 @@ async def test_mop_intensity_select_entity_async(mock_coordinator):
 
         # Should map "Max" to "High" for the device command
         mock_build.assert_called_with(
-            "set_water_level", api_type=mock_coordinator.data.api_type, water_level="High"
+            "set_water_level",
+            api_type=mock_coordinator.data.api_type,
+            water_level="High",
         )
         mock_coordinator.async_send_command.assert_called_with(
             {"cmd": "water_level_cmd"}

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -82,27 +82,29 @@ async def test_vacuum_commands(mock_coordinator, mock_config_entry):
     with patch("custom_components.robovac_mqtt.vacuum.build_command") as mock_build:
         mock_build.return_value = {"cmd": "val"}
 
+        api = mock_coordinator.data.api_type
+
         # Start (Default/Docked)
         await entity.async_start()
-        mock_build.assert_called_with("start_auto")
+        mock_build.assert_called_with("start_auto", api_type=api)
         mock_coordinator.async_send_command.assert_called_with({"cmd": "val"})
 
         # Start (Paused -> Resume)
         mock_coordinator.data.activity = "paused"
         await entity.async_start()
-        mock_build.assert_called_with("play")
+        mock_build.assert_called_with("play", api_type=api)
 
         # Stop
         await entity.async_stop()
-        mock_build.assert_called_with("stop")
+        mock_build.assert_called_with("stop", api_type=api)
 
         # Pause
         await entity.async_pause()
-        mock_build.assert_called_with("pause")
+        mock_build.assert_called_with("pause", api_type=api)
 
         # Return to base
         await entity.async_return_to_base()
-        mock_build.assert_called_with("return_to_base")
+        mock_build.assert_called_with("return_to_base", api_type=api)
 
         # Spot Clean
         await entity.async_clean_spot()
@@ -110,7 +112,9 @@ async def test_vacuum_commands(mock_coordinator, mock_config_entry):
 
         # Locate
         await entity.async_locate()
-        mock_build.assert_called_with("find_robot", active=True)
+        mock_build.assert_called_with(
+            "find_robot", api_type=mock_coordinator.data.api_type, active=True
+        )
 
 
 @pytest.mark.asyncio
@@ -126,7 +130,9 @@ async def test_set_fan_speed(mock_coordinator, mock_config_entry):
 
         speed_max = EUFY_CLEAN_CLEAN_SPEED.MAX.value
         await entity.async_set_fan_speed(speed_max)
-        mock_build.assert_called_with("set_fan_speed", fan_speed=speed_max)
+        mock_build.assert_called_with(
+            "set_fan_speed", api_type=mock_coordinator.data.api_type, fan_speed=speed_max
+        )
         mock_coordinator.async_send_command.assert_called_with({"cmd": "speed"})
 
         # Invalid speed

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -108,7 +108,7 @@ async def test_vacuum_commands(mock_coordinator, mock_config_entry):
 
         # Spot Clean
         await entity.async_clean_spot()
-        mock_build.assert_called_with("clean_spot")
+        mock_build.assert_called_with("clean_spot", api_type=api)
 
         # Locate
         await entity.async_locate()
@@ -131,7 +131,9 @@ async def test_set_fan_speed(mock_coordinator, mock_config_entry):
         speed_max = EUFY_CLEAN_CLEAN_SPEED.MAX.value
         await entity.async_set_fan_speed(speed_max)
         mock_build.assert_called_with(
-            "set_fan_speed", api_type=mock_coordinator.data.api_type, fan_speed=speed_max
+            "set_fan_speed",
+            api_type=mock_coordinator.data.api_type,
+            fan_speed=speed_max,
         )
         mock_coordinator.async_send_command.assert_called_with({"cmd": "speed"})
 
@@ -159,6 +161,34 @@ async def test_async_send_command_raw(mock_coordinator, mock_config_entry):
         mock_coordinator.data.map_id = 9
         await entity.async_send_command("room_clean", params={"room_ids": [1]})
         mock_build.assert_called_with("room_clean", room_ids=[1], map_id=9)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command", ["start_auto", "pause", "return_to_base", "set_fan_speed"]
+)
+async def test_async_send_command_raw_passes_api_type(
+    mock_coordinator, mock_config_entry, command
+):
+    """Raw vacuum.send_command must route through the device's DPS protocol.
+
+    Regression: scalar (e.g. G50) devices got novel/protobuf payloads when
+    commands were sent via the generic service instead of entity methods.
+    """
+    mock_coordinator.data = VacuumState(api_type="scalar")
+    entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
+
+    with patch("custom_components.robovac_mqtt.vacuum.build_command") as mock_build:
+        mock_build.return_value = {"cmd": "raw"}
+
+        params = {"fan_speed": "Max"} if command == "set_fan_speed" else None
+        await entity.async_send_command(command, params=params)
+        assert mock_build.call_args.kwargs["api_type"] == "scalar"
+        mock_coordinator.async_send_command.assert_called_with({"cmd": "raw"})
+
+        # An explicit api_type in params still wins over the detected one.
+        await entity.async_send_command(command, params={"api_type": "novel"})
+        assert mock_build.call_args.kwargs["api_type"] == "novel"
 
 
 @pytest.fixture


### PR DESCRIPTION
## What
Adds support for the **Eufy Clean G50 (T2210)** — a **vacuum-only, cloud-only (Anker MQTT)** model with **no Tuya local key**. It worked with neither this component (tuned for the X-series length-prefixed protobuf DPS) nor Tuya-local integrations (no local key).

The G50 speaks the **Tuya DPS schema as plain ints/JSON over the existing Anker MQTT transport** — distinct from the X-series protobuf, and distinct from #110's separate Tuya-Cloud/local transport.

## Approach (no model hardcoding; X-series path untouched)
- **Protocol detection by value shape**, reusing the `EufyLogin.checkApiType` / per-device `apiType` already in `main`: `api_type` = `"novel"` (protobuf) vs `"scalar"` (Tuya int/JSON). `checkApiType` is fixed to classify by *value shape* because the G50 reuses protobuf DPS **numbers** (153/154) with **int** values (a key-presence check misclassifies it as novel).
- A **dedicated scalar parser + command builders**, dispatched on `api_type`.
- **Entity creation gated** so vacuum-only devices don't surface mop/station/map entities; the suction list and vacuum features are adjusted (BoostIQ is a separate switch; no `CLEAN_AREA`/`CLEAN_SPOT`).

## Works — verified live on a real G50 (read + write)
- **State:** battery, activity/state machine, charging, suction (4-step), BoostIQ, cleaning pattern (Arranged/Random), volume, DND, child-lock, auto-return, accessory life %, schedules (read-only), error codes, cleaning time (s) / area (m²).
- **Commands:** start / pause / resume / return-home, suction, BoostIQ, cleaning pattern, volume, DND, child-lock, find-robot, accessory reset, detangle roller brush.

## Relationship to #110
**Complementary, not conflicting.** #110 adds a *separate* Tuya-Cloud/local transport for devices unreachable on MQTT; this handles Tuya-**schema** devices reachable on the **existing Anker MQTT**, and reuses the `apiType` concept. Based on `main`.

## Testing
Reverse-engineered from a real G50 via MQTT capture; the DPS map was cross-checked against the canonical Tuya robovac schema (`damacus/robovac`'s `T2210`), then every entity + command was verified live on the device. 218 unit tests (scalar parser, command builders, protocol detection, entity behaviour). Full DPS evidence + capture methodology in `docs/g50_capture/FINDINGS.md`.

## Screenshots

<details>
<summary><b>Main vacuum card — full cleaning lifecycle</b> (docked → cleaning → returning → idle)</summary>
<br>
<table>
<tr>
<td align="center"><b>Docked / charging</b><br><img width="100%" src="https://github.com/user-attachments/assets/d58d9050-fc44-4c8a-9121-bf38f1446002" /></td>
<td align="center"><b>Cleaning</b><br><img width="100%" src="https://github.com/user-attachments/assets/c667cb4a-daef-4776-8701-cc8690f47fed" /></td>
</tr>
<tr>
<td align="center"><b>Returning to dock</b><br><img width="100%" src="https://github.com/user-attachments/assets/6ac47553-f8cd-45fd-af39-ca36109e9e9f" /></td>
<td align="center"><b>Idle</b><br><img width="100%" src="https://github.com/user-attachments/assets/3fdab5b9-0d8f-4dce-8b2b-5ab805fabda8" /></td>
</tr>
</table>
</details>

<details>
<summary><b>Controls &amp; sensors</b> (entity more-info cards)</summary>
<br>
<table>
<tr>
<td align="center"><b>Suction level</b><br><img width="100%" src="https://github.com/user-attachments/assets/25842316-68ba-4dc5-ab24-ba8fd7e5518a" /></td>
<td align="center"><b>Voice volume</b><br><img width="100%" src="https://github.com/user-attachments/assets/c2414e2f-d684-4fca-a800-f0998b5019f8" /></td>
</tr>
<tr>
<td align="center"><b>Battery</b><br><img width="100%" src="https://github.com/user-attachments/assets/3db4103b-481d-474b-af5f-11c2d94c2062" /></td>
<td align="center"><b>Rolling brush remaining</b><br><img width="100%" src="https://github.com/user-attachments/assets/6d02137b-c4d1-4ed1-ac61-6676b15948e7" /></td>
</tr>
<tr>
<td align="center"><b>Error message</b><br><img width="100%" src="https://github.com/user-attachments/assets/16b6f9e8-567f-4cdb-8f8c-f7f098192b92" /></td>
<td></td>
</tr>
</table>
</details>

<details>
<summary><b>Device page</b> — info, controls, configuration &amp; diagnostics</summary>
<br>
<table>
<tr>
<td align="center" valign="top"><b>Info · Controls · Sensors</b><br><img width="100%" src="https://github.com/user-attachments/assets/0b3b4004-048f-41e0-92be-cc0c6a7ab8fb" /></td>
<td align="center" valign="top"><b>Configuration</b><br><img width="100%" src="https://github.com/user-attachments/assets/01d59b6b-8b9b-4d6a-a74b-54c38227be89" /></td>
<td align="center" valign="top"><b>Diagnostic</b><br><img width="100%" src="https://github.com/user-attachments/assets/df4c8169-140d-4548-a27c-a9b54d61d189" /></td>
</tr>
</table>
</details>

<details>
<summary><b>Integration setup &amp; entity states</b></summary>
<br>
<p align="center"><b>Integration</b><br><img width="60%" src="https://github.com/user-attachments/assets/0e42b26a-65fc-4fc8-a321-9dc8c7d6bcc5" /></p>

Entity states &amp; attributes (Developer Tools):

<table>
<tr>
<td><img width="100%" src="https://github.com/user-attachments/assets/d11148c2-e331-4641-b4c8-126aeec95885" /></td>
<td><img width="100%" src="https://github.com/user-attachments/assets/4017131d-4a63-4576-bbae-e871cdead8b0" /></td>
</tr>
<tr>
<td><img width="100%" src="https://github.com/user-attachments/assets/babcc62a-a175-45af-b491-35c2f77047c8" /></td>
<td><img width="100%" src="https://github.com/user-attachments/assets/dac64660-0159-4e45-ad44-a05da3946023" /></td>
</tr>
<tr>
<td><img width="100%" src="https://github.com/user-attachments/assets/6f254a17-ae8a-4444-9b20-61aec6304e69" /></td>
<td></td>
</tr>
</table>
</details>
