### PR TITLE
feat: zone cleaning via send_command (SelectZonesClean dispatch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,30 @@ data:
         clean_mode: "vacuum"
 ```
 
+### Zone Cleaning
+
+Clean one or more free-form rectangles instead of whole rooms. Each zone is given as
+normalized coordinates `[x0, y0, x1, y1]` — fractions (`0`–`1`) of the rendered map
+image, with `(0, 0)` at the **top-left** and `(1, 1)` at the **bottom-right** of the map
+camera image. They are converted to the robot's world frame against the current map, so the
+map must have been received at least once (run a clean or dock first).
+
+```yaml
+action: vacuum.send_command
+target:
+  entity_id: vacuum.eufy_omni_c28
+data:
+  command: zone_clean
+  params:
+    zones:
+      - [0.05, 0.70, 0.35, 0.95]   # bottom-left corner of the map
+      - [0.40, 0.40, 0.60, 0.60]   # a box in the centre
+    clean_times: 1
+```
+
+`map_id` is taken from the current map automatically; pass it explicitly to override. The
+robot uses its current cleaning mode (vacuum / mop) and fan settings for the zone run.
+
 ### Map and Room IDs
 - **Active Map sensor** — `sensor.<device>_active_map` shows the current map ID (needed for service calls)
 - **Room IDs** — available in the vacuum entity's `rooms` / `segments` state attributes; inspect via **Developer Tools → States**

--- a/README.md
+++ b/README.md
@@ -234,6 +234,27 @@ data:
 `map_id` is taken from the current map automatically; pass it explicitly to override. The
 robot uses its current cleaning mode (vacuum / mop) and fan settings for the zone run.
 
+#### Drawing zones — bundled card
+
+Hand-writing normalized coordinates is fiddly, so the integration **bundles a small
+Lovelace card** that lets you drag the boxes on the live map instead. It ships inside the
+integration and is **auto-registered on setup** — there's no `www/` copy and no Lovelace
+*Resources* entry to add. Just drop it on a dashboard:
+
+```yaml
+type: custom:zone-clean-card
+vacuum: vacuum.eufy_omni_c28
+camera: camera.eufy_omni_c28_map
+# title: Zone Clean      # optional
+# selects:               # optional — defaults to auto-discovering the vacuum's selects
+#   - select.eufy_omni_c28_cleaning_mode
+#   - select.eufy_omni_c28_clean_speed
+```
+
+Draw up to 10 boxes, set suction/mode via the surfaced `select` entities, and hit **Clean**
+— it fires the `zone_clean` send_command shown above. The map only renders after the robot
+has cleaned once (or you've edited the map in the app).
+
 ### Map and Room IDs
 - **Active Map sensor** — `sensor.<device>_active_map` shows the current map ID (needed for service calls)
 - **Room IDs** — available in the vacuum entity's `rooms` / `segments` state attributes; inspect via **Developer Tools → States**

--- a/custom_components/robovac_mqtt/__init__.py
+++ b/custom_components/robovac_mqtt/__init__.py
@@ -50,16 +50,27 @@ async def _async_register_frontend_card(hass: HomeAssistant) -> None:
     # ?v=<version> busts the browser cache whenever the integration updates.
     card_url = f"{_CARD_URL_PATH}?v={integration.version}"
 
-    await hass.http.async_register_static_paths(
-        [
-            StaticPathConfig(
-                _CARD_URL_PATH,
-                str(_FRONTEND_DIR / _CARD_FILENAME),
-                cache_headers=False,
-            )
-        ]
-    )
-    add_extra_js_url(hass, card_url)
+    # The card is a best-effort enhancement. In a normal install the frontend is
+    # already set up by the time this entry loads, but we don't declare it as a
+    # hard dependency: a not-yet-ready (or headless) frontend must never fail the
+    # vacuum integration's setup. add_extra_js_url needs the frontend in place.
+    try:
+        await hass.http.async_register_static_paths(
+            [
+                StaticPathConfig(
+                    _CARD_URL_PATH,
+                    str(_FRONTEND_DIR / _CARD_FILENAME),
+                    cache_headers=False,
+                )
+            ]
+        )
+        add_extra_js_url(hass, card_url)
+    except Exception:  # frontend not ready; skip the optional card, keep the entry
+        _LOGGER.warning(
+            "Could not register the bundled zone-clean card; skipping", exc_info=True
+        )
+        return
+
     domain_data["card_registered"] = True
     _LOGGER.debug("Registered bundled zone-clean card at %s", card_url)
 

--- a/custom_components/robovac_mqtt/__init__.py
+++ b/custom_components/robovac_mqtt/__init__.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 import logging
 import random
 import string
+from pathlib import Path
 
+from homeassistant.components.frontend import add_extra_js_url
+from homeassistant.components.http import StaticPathConfig
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+from homeassistant.loader import async_get_integration
 
 from .api.cloud import EufyLogin
 from .const import DOMAIN
@@ -26,10 +30,46 @@ PLATFORMS: list[Platform] = [
 ]
 _LOGGER = logging.getLogger(__name__)
 
+_FRONTEND_DIR = Path(__file__).parent / "frontend"
+_CARD_FILENAME = "zone-clean-card.js"
+_CARD_URL_PATH = f"/{DOMAIN}/{_CARD_FILENAME}"
+
+
+async def _async_register_frontend_card(hass: HomeAssistant) -> None:
+    """Serve and register the bundled zone-clean Lovelace card (once).
+
+    Shipping the card inside the integration keeps it in lock-step with the
+    ``zone_clean`` send_command handler — a single install delivers both, with no
+    manual ``www/`` copy or Lovelace resource entry for the user.
+    """
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    if domain_data.get("card_registered"):
+        return
+
+    integration = await async_get_integration(hass, DOMAIN)
+    # ?v=<version> busts the browser cache whenever the integration updates.
+    card_url = f"{_CARD_URL_PATH}?v={integration.version}"
+
+    await hass.http.async_register_static_paths(
+        [
+            StaticPathConfig(
+                _CARD_URL_PATH,
+                str(_FRONTEND_DIR / _CARD_FILENAME),
+                cache_headers=False,
+            )
+        ]
+    )
+    add_extra_js_url(hass, card_url)
+    domain_data["card_registered"] = True
+    _LOGGER.debug("Registered bundled zone-clean card at %s", card_url)
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Initialize the integration."""
     entry.async_on_unload(entry.add_update_listener(update_listener))
+
+    # Serve + register the bundled zone-clean Lovelace card (once across entries).
+    await _async_register_frontend_card(hass)
 
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]

--- a/custom_components/robovac_mqtt/api/commands.py
+++ b/custom_components/robovac_mqtt/api/commands.py
@@ -20,8 +20,13 @@ from ..const import (
     VOICE_CATALOG,
 )
 from ..proto.cloud.clean_param_pb2 import CleanParam, CleanParamRequest, Fan
+from ..proto.cloud.common_pb2 import Point, Quadrangle
 from ..proto.cloud.consumable_pb2 import ConsumableRequest
-from ..proto.cloud.control_pb2 import ModeCtrlRequest, SelectRoomsClean
+from ..proto.cloud.control_pb2 import (
+    ModeCtrlRequest,
+    SelectRoomsClean,
+    SelectZonesClean,
+)
 from ..proto.cloud.map_edit_pb2 import MapEditRequest
 from ..proto.cloud.station_pb2 import StationRequest
 from ..proto.cloud.undisturbed_pb2 import UndisturbedRequest
@@ -147,6 +152,54 @@ def build_room_clean_command(
                 ModeCtrlRequest.Method, int(EUFY_CLEAN_CONTROL.START_SELECT_ROOMS_CLEAN)
             ),
             select_rooms_clean=rooms_clean,
+        )
+    )
+    return {DPS_MAP["PLAY_PAUSE"]: value}
+
+
+def build_zone_clean_command(
+    zones_cm: list[list[tuple[int, int]]],
+    map_id: int = 3,
+    clean_times: int = 1,
+) -> dict[str, str]:
+    """Build command to clean one or more free-form zones (select-zones clean).
+
+    *zones_cm* is a list of quadrilaterals; each quad is a list of four
+    ``(x, y)`` corner points in centimetres (the device's world frame, where
+    1 unit = 1 cm = metres * 100), ordered around the rectangle.  Callers
+    convert from screen/normalized coordinates before reaching this builder
+    (see ``EufyCleanCoordinator.normalized_rects_to_quads_cm``).
+
+    Dispatch is identical to ``build_room_clean_command`` — a ``ModeCtrlRequest``
+    with method ``START_SELECT_ZONES_CLEAN`` carried on DPS 152.
+    """
+    proto_zones: list[SelectZonesClean.Zone] = []
+    for quad in zones_cm:
+        if len(quad) != 4:
+            _LOGGER.warning(
+                "Zone needs exactly 4 corner points, got %d — skipped", len(quad)
+            )
+            continue
+        pts = [Point(x=int(round(px)), y=int(round(py))) for px, py in quad]
+        proto_zones.append(
+            SelectZonesClean.Zone(
+                quadrangle=Quadrangle(p0=pts[0], p1=pts[1], p2=pts[2], p3=pts[3]),
+                clean_times=max(1, int(clean_times)),
+            )
+        )
+
+    if not proto_zones:
+        return {}
+
+    value = encode_message(
+        ModeCtrlRequest(
+            method=cast(
+                ModeCtrlRequest.Method, int(EUFY_CLEAN_CONTROL.START_SELECT_ZONES_CLEAN)
+            ),
+            select_zones_clean=SelectZonesClean(
+                zones=proto_zones,
+                map_id=int(map_id),
+            ),
         )
     )
     return {DPS_MAP["PLAY_PAUSE"]: value}
@@ -557,6 +610,12 @@ def build_command(
             kwargs.get("room_ids", []),
             kwargs.get("map_id", 3),
             kwargs.get("mode", "GENERAL"),
+        )
+    if cmd == "zone_clean":
+        return build_zone_clean_command(
+            kwargs.get("zones_cm", []),
+            kwargs.get("map_id", 3),
+            int(kwargs.get("clean_times", 1)),
         )
     if cmd == "set_room_custom":
         return build_set_room_custom_command(

--- a/custom_components/robovac_mqtt/coordinator.py
+++ b/custom_components/robovac_mqtt/coordinator.py
@@ -375,6 +375,57 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
             return px, py
         return None
 
+    def normalized_rects_to_quads_cm(
+        self, rects: list[Any]
+    ) -> list[list[tuple[int, int]]]:
+        """Convert normalized rectangles on the rendered map image to world-cm quads.
+
+        Each rect is ``(x0, y0, x1, y1)`` in fractions (0-1) of the rendered map
+        image, origin at the TOP-LEFT (HA camera-image convention).  Returns one
+        4-corner quadrilateral per rect in centimetres (the device world frame),
+        ready for ``build_zone_clean_command``.  Returns ``[]`` if no map has been
+        received yet.
+
+        This is the exact inverse of ``render_map_png``'s forward transform.  The
+        render scale cancels out — normalized coords are already relative to the
+        scaled output, so only the grid dimensions, resolution and the baked-in
+        Y-flip remain::
+
+            wx = origin_x + nx * width  * res
+            wy = origin_y + (height - 1 - ny * height) * res
+        """
+        md = self._map_data
+        if md is None:
+            return []
+        res = md.resolution or 5
+        w, h = md.width, md.height
+
+        def _to_cm(nx: float, ny: float) -> tuple[int, int]:
+            nx = min(max(float(nx), 0.0), 1.0)
+            ny = min(max(float(ny), 0.0), 1.0)
+            wx = md.origin_x + nx * w * res
+            wy = md.origin_y + (h - 1 - ny * h) * res
+            return round(wx), round(wy)
+
+        quads: list[list[tuple[int, int]]] = []
+        for rect in rects:
+            try:
+                x0, y0, x1, y1 = (float(v) for v in rect)
+            except (TypeError, ValueError):
+                _LOGGER.warning("Ignoring malformed zone rect: %s", rect)
+                continue
+            lo_x, hi_x = sorted((x0, x1))
+            lo_y, hi_y = sorted((y0, y1))
+            quads.append(
+                [
+                    _to_cm(lo_x, lo_y),  # top-left
+                    _to_cm(hi_x, lo_y),  # top-right
+                    _to_cm(hi_x, hi_y),  # bottom-right
+                    _to_cm(lo_x, hi_y),  # bottom-left
+                ]
+            )
+        return quads
+
     def _get_robot_status(self) -> str | None:
         """Return a status badge string for the current dock/activity state."""
         dock = self.data.dock_status

--- a/custom_components/robovac_mqtt/frontend/zone-clean-card.js
+++ b/custom_components/robovac_mqtt/frontend/zone-clean-card.js
@@ -1,0 +1,511 @@
+/*
+ * zone-clean-card  —  draw-a-box zone cleaning for Eufy (jeppesens/eufy-clean)
+ * ----------------------------------------------------------------------------
+ * Draw boxes on the live map, pick your settings, hit Clean.
+ *
+ * BUNDLED CARD: this file ships inside the eufy-clean integration and is
+ * auto-registered on setup — there is no www/ copy and no Lovelace "Resources"
+ * entry to add. Just drop the card on a dashboard:
+ *
+ *       type: custom:zone-clean-card
+ *       vacuum: vacuum.your_robot
+ *       camera: camera.your_robot_map
+ *       # title: Zone Clean        # optional
+ *       # selects:                 # optional — if omitted, every select.<vacuum-slug>_*
+ *       #   - select.your_robot_suction_level   #   entity is auto-surfaced. List them to
+ *       #   - select.your_robot_water_level     #   pick/order a specific subset.
+ *
+ * What it does (and nothing more):
+ *   1. shows the vacuum's live map camera as a backdrop
+ *   2. lets you rubber-band up to 10 zones on it
+ *   3. surfaces the vacuum's setting `select` entities (you change them live; the zone clean
+ *      runs with whatever they're set to — no params embedded)
+ *   4. fires vacuum.send_command { command: zone_clean, params: { zones, clean_times } }
+ *
+ * It pairs with the integration's `zone_clean` send_command handler, which takes NORMALIZED
+ * (0-1) rects of the rendered map image (top-left origin) and converts them to world-cm
+ * itself. Because this card draws on the image at its natural aspect ratio, the drawn
+ * fraction IS the image fraction — no letterbox correction needed. Brand-agnostic otherwise:
+ * any vacuum + camera + select entities work.
+ *
+ * Note: the map only renders after the robot has cleaned once (or you edit the map in the app).
+ */
+
+const MAX_ZONES = 10;
+const MIN_FRAC = 0.012; // reject degenerate drags smaller than ~1% of the map in either axis
+const clamp01 = (v) => Math.min(Math.max(v, 0), 1);
+
+class ZoneCleanCard extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._zones = [];          // committed zones: {x0,y0,x1,y1} normalized
+    this._drag = null;         // in-progress drag: {x0,y0,x1,y1} normalized
+    this._cleanTimes = 1;      // passes per zone (Zone.clean_times)
+    this._built = false;
+    this._lastImgSrc = "";
+    this._optSig = {};         // per-select option-list signature, to avoid rebuilding while open
+  }
+
+  setConfig(config) {
+    if (!config || !config.vacuum) throw new Error("zone-clean-card: 'vacuum' is required");
+    if (!config.camera) throw new Error("zone-clean-card: 'camera' is required");
+    this._config = {
+      title: "Zone Clean",
+      selects: [],
+      ...config,
+    };
+    this._zones = [];
+    this._drag = null;
+    if (this._built) this._selectsKey = null; // config changed at runtime -> rebuild on next sync
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    if (!this._built) this._build();
+    this._syncDynamic();
+  }
+
+  getCardSize() {
+    return 8;
+  }
+
+  connectedCallback() {
+    this._startPolling();
+  }
+
+  disconnectedCallback() {
+    clearTimeout(this._pollTimer);
+    this._pollTimer = null;
+  }
+
+  // Keep the map fresh. The camera re-renders the map WITHOUT always bumping the
+  // entity's last_updated, so refreshing only on a state change leaves it stale (the
+  // "stale map" symptom). Poll the image on a cadence instead: ~3s while the robot is
+  // moving (matches the fork's ~2s render throttle), and just re-check (no re-fetch)
+  // every 10s while it's parked — the map doesn't change when docked, and a real state
+  // change still refreshes instantly via _syncDynamic. Stops when the card leaves the DOM.
+  _startPolling() {
+    clearTimeout(this._pollTimer);
+    const tick = () => {
+      const active = this._vacuumActive();
+      if (active) this._refreshMap();
+      this._pollTimer = setTimeout(tick, active ? 3000 : 10000);
+    };
+    this._pollTimer = setTimeout(tick, 3000);
+  }
+
+  _vacuumActive() {
+    const v = this._hass && this._hass.states[this._config.vacuum];
+    const s = v && v.state;
+    return s === "cleaning" || s === "returning";
+  }
+
+  // Re-fetch the camera image with a fresh cache-bust so the latest render shows.
+  // Skipped mid-draw so the backdrop never swaps out from under an in-progress box.
+  _refreshMap() {
+    if (!this._built || !this._hass || this._drag) return;
+    const cam = this._hass.states[this._config.camera];
+    const pic = cam && cam.attributes && cam.attributes.entity_picture;
+    if (!pic) return;
+    const src = pic + (pic.includes("?") ? "&" : "?") + "_=" + Date.now();
+    this._els.img.src = src;
+    this._lastImgSrc = src;
+  }
+
+  // --- one-time DOM skeleton + listeners -----------------------------------------------------
+  _build() {
+    const c = this._config;
+    this.shadowRoot.innerHTML = `
+      <style>
+        ha-card { padding: 12px 16px 16px; }
+        .title { font-size: 1.1rem; font-weight: 500; margin-bottom: 8px; }
+        .map-wrap { position: relative; width: 100%; max-width: 520px; margin: 0 auto;
+                    border-radius: 8px; overflow: hidden; background: var(--secondary-background-color); }
+        .map-wrap img { display: block; width: 100%; height: auto; user-select: none; -webkit-user-drag: none; }
+        /* width/height:100% are REQUIRED — an inline <svg> is a replaced element with a
+           default 300x150 intrinsic size, and inset:0 alone does NOT stretch it (so it'd
+           sit at 300x150 in the top-left, and only that corner would be drawable). */
+        .overlay { position: absolute; inset: 0; width: 100%; height: 100%;
+                   touch-action: none; cursor: crosshair; }
+        .nomap { padding: 40px 12px; text-align: center; color: var(--secondary-text-color);
+                 font-size: 0.9rem; }
+        .settings { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+                    gap: 8px 12px; margin-top: 12px; }
+        .field { display: flex; flex-direction: column; gap: 2px; }
+        .field label { font-size: 0.72rem; color: var(--secondary-text-color); text-transform: uppercase;
+                       letter-spacing: 0.03em; }
+        .field select { padding: 6px 8px; border-radius: 6px; border: 1px solid var(--divider-color);
+                        background: var(--card-background-color); color: var(--primary-text-color);
+                        font-size: 0.9rem; }
+        .controls { display: flex; align-items: center; gap: 10px; margin-top: 14px; flex-wrap: wrap; }
+        .passes { display: flex; align-items: center; gap: 6px; font-size: 0.85rem;
+                  color: var(--secondary-text-color); }
+        .passes input { width: 52px; padding: 5px 6px; border-radius: 6px;
+                        border: 1px solid var(--divider-color); background: var(--card-background-color);
+                        color: var(--primary-text-color); font-size: 0.9rem; }
+        .status { flex: 1 1 100%; font-size: 0.82rem; color: var(--secondary-text-color); }
+        button { font: inherit; padding: 8px 14px; border-radius: 8px; border: none; cursor: pointer; }
+        button:disabled { opacity: 0.45; cursor: default; }
+        .clean { background: var(--primary-color); color: var(--text-primary-color, #fff); font-weight: 500; }
+        .ghost { background: transparent; color: var(--primary-text-color); border: 1px solid var(--divider-color); }
+        rect.zone { fill: var(--primary-color); fill-opacity: 0.22; stroke: var(--primary-color); stroke-width: 2; }
+        rect.draft { fill: var(--primary-color); fill-opacity: 0.12; stroke: var(--primary-color);
+                     stroke-width: 2; stroke-dasharray: 6 4; }
+        text.num { fill: var(--text-primary-color, #fff); font-size: 13px; font-weight: 700;
+                   paint-order: stroke; stroke: var(--primary-color); stroke-width: 3; }
+      </style>
+      <ha-card>
+        <div class="title"></div>
+        <div class="map-wrap">
+          <img class="map" alt="vacuum map" />
+          <svg class="overlay" preserveAspectRatio="none"></svg>
+          <div class="nomap" hidden>Waiting for the map… run a clean once (or edit the map in the app) so it renders.</div>
+        </div>
+        <div class="settings"></div>
+        <div class="controls">
+          <span class="passes">Passes
+            <input class="ct" type="number" min="1" max="10" step="1" value="1" />
+          </span>
+          <button class="ghost clear">Clear</button>
+          <button class="clean" disabled>Clean</button>
+          <span class="status"></span>
+        </div>
+      </ha-card>
+    `;
+
+    this._els = {
+      title: this.shadowRoot.querySelector(".title"),
+      img: this.shadowRoot.querySelector("img.map"),
+      overlay: this.shadowRoot.querySelector("svg.overlay"),
+      nomap: this.shadowRoot.querySelector(".nomap"),
+      settings: this.shadowRoot.querySelector(".settings"),
+      ct: this.shadowRoot.querySelector("input.ct"),
+      clear: this.shadowRoot.querySelector("button.clear"),
+      clean: this.shadowRoot.querySelector("button.clean"),
+      status: this.shadowRoot.querySelector(".status"),
+    };
+    this._els.title.textContent = c.title;
+
+    // draw handlers (pointer events = mouse + touch)
+    const ov = this._els.overlay;
+    const toFrac = (e) => {
+      const r = ov.getBoundingClientRect();
+      return { x: clamp01((e.clientX - r.left) / r.width), y: clamp01((e.clientY - r.top) / r.height) };
+    };
+    ov.addEventListener("pointerdown", (e) => {
+      if (this._els.nomap.hidden === false) return; // no map yet
+      ov.setPointerCapture(e.pointerId);
+      const p = toFrac(e);
+      this._drag = { x0: p.x, y0: p.y, x1: p.x, y1: p.y };
+      this._renderOverlay();
+    });
+    ov.addEventListener("pointermove", (e) => {
+      if (!this._drag) return;
+      const p = toFrac(e);
+      this._drag.x1 = p.x;
+      this._drag.y1 = p.y;
+      this._renderOverlay();
+    });
+    const finish = (e) => {
+      if (!this._drag) return;
+      const d = this._drag;
+      this._drag = null;
+      const x0 = Math.min(d.x0, d.x1), x1 = Math.max(d.x0, d.x1);
+      const y0 = Math.min(d.y0, d.y1), y1 = Math.max(d.y0, d.y1);
+      if (x1 - x0 >= MIN_FRAC && y1 - y0 >= MIN_FRAC && this._zones.length < MAX_ZONES) {
+        this._zones.push({ x0, y0, x1, y1 });
+      }
+      this._renderOverlay();
+      this._syncControls();
+    };
+    ov.addEventListener("pointerup", finish);
+    ov.addEventListener("pointercancel", finish);
+
+    this._els.ct.addEventListener("change", () => {
+      let n = parseInt(this._els.ct.value, 10);
+      if (!Number.isFinite(n)) n = 1;
+      n = Math.min(Math.max(n, 1), 10);
+      this._cleanTimes = n;
+      this._els.ct.value = String(n);
+    });
+    this._els.clear.addEventListener("click", () => {
+      this._zones = [];
+      this._drag = null;
+      this._renderOverlay();
+      this._syncControls();
+      this._setStatus("");
+    });
+    this._els.clean.addEventListener("click", () => this._clean());
+
+    this._selectsKey = null;
+    this._selectEls = {};
+    this._built = true;
+  }
+
+  // --- settings selects ----------------------------------------------------------------------
+  // Effective select list: explicit `selects:` if given, else auto-discover every
+  // `select.<vacuum-slug>_*` entity so the card is plug-in with just vacuum + camera.
+  _effectiveSelects() {
+    if (this._config.selects && this._config.selects.length) return this._config.selects;
+    if (!this._hass) return [];
+    const slug = (this._config.vacuum.split(".")[1] || "");
+    if (!slug) return [];
+    return Object.keys(this._hass.states)
+      .filter((e) => e.startsWith(`select.${slug}_`))
+      .sort();
+  }
+
+  _rebuildSelects(list) {
+    const wrap = this._els.settings;
+    wrap.innerHTML = "";
+    this._selectEls = {};
+    this._optSig = {};
+    for (const eid of list || []) {
+      const field = document.createElement("div");
+      field.className = "field";
+      const label = document.createElement("label");
+      const sel = document.createElement("select");
+      sel.dataset.entity = eid;
+      sel.addEventListener("change", () => {
+        if (!this._hass) return;
+        this._hass.callService("select", "select_option", {
+          entity_id: eid,
+          option: sel.value,
+        });
+      });
+      field.appendChild(label);
+      field.appendChild(sel);
+      wrap.appendChild(field);
+      this._selectEls[eid] = { field, label, sel };
+    }
+  }
+
+  // --- per-hass-update sync (image, selects, status) -----------------------------------------
+  _syncDynamic() {
+    const hass = this._hass;
+    if (!hass) return;
+    const cam = hass.states[this._config.camera];
+
+    // backdrop — show/hide + an INSTANT refresh whenever the camera entity changes
+    // (last_updated) or on first paint. Between those, _startPolling() keeps it fresh
+    // (the camera re-renders the map without always bumping last_updated).
+    const pic = cam && cam.attributes && cam.attributes.entity_picture;
+    if (pic) {
+      this._els.img.hidden = false;
+      this._els.nomap.hidden = true;
+      const lu = cam.last_updated || "";
+      if (lu !== this._lastCamUpdate || !this._lastImgSrc) {
+        this._lastCamUpdate = lu;
+        this._refreshMap();
+      }
+    } else {
+      this._els.img.removeAttribute("src");
+      this._lastImgSrc = "";
+      this._els.img.hidden = true;
+      this._els.nomap.hidden = false;
+    }
+
+    // settings selects — (re)build the controls if the effective list changed
+    const eff = this._effectiveSelects();
+    const key = eff.join(",");
+    if (key !== this._selectsKey) {
+      this._rebuildSelects(eff);
+      this._selectsKey = key;
+    }
+    for (const [eid, refs] of Object.entries(this._selectEls || {})) {
+      const st = hass.states[eid];
+      if (!st) {
+        refs.field.style.display = "none";
+        continue;
+      }
+      refs.field.style.display = "";
+      const fname = (st.attributes && st.attributes.friendly_name) || eid;
+      refs.label.textContent = fname;
+      const opts = (st.attributes && st.attributes.options) || [];
+      const sig = opts.join("");
+      if (sig !== this._optSig[eid]) {
+        refs.sel.innerHTML = opts.map((o) => `<option value="${o}">${o}</option>`).join("");
+        this._optSig[eid] = sig;
+      }
+      // don't fight the user if the dropdown is open / focused
+      if (this.shadowRoot.activeElement !== refs.sel) refs.sel.value = st.state;
+    }
+
+    this._syncControls();
+  }
+
+  _syncControls() {
+    const n = this._zones.length;
+    this._els.clean.disabled = n === 0;
+    this._els.clean.textContent = n > 0 ? `Clean ${n} zone${n > 1 ? "s" : ""}` : "Clean";
+    if (!this._statusSticky) {
+      this._els.status.textContent = n
+        ? `${n}/${MAX_ZONES} zones drawn`
+        : "Drag on the map to draw a zone.";
+    }
+  }
+
+  _setStatus(msg) {
+    this._statusSticky = !!msg;
+    this._els.status.textContent = msg;
+    if (msg) {
+      clearTimeout(this._statusTimer);
+      this._statusTimer = setTimeout(() => {
+        this._statusSticky = false;
+        this._syncControls();
+      }, 4000);
+    }
+  }
+
+  // --- overlay render ------------------------------------------------------------------------
+  _renderOverlay() {
+    const parts = [];
+    this._zones.forEach((z, i) => {
+      const x = z.x0 * 100, y = z.y0 * 100, w = (z.x1 - z.x0) * 100, h = (z.y1 - z.y0) * 100;
+      parts.push(`<rect class="zone" x="${x}%" y="${y}%" width="${w}%" height="${h}%" />`);
+      parts.push(`<text class="num" x="${x}%" y="${y}%" dx="6" dy="16">${i + 1}</text>`);
+    });
+    if (this._drag) {
+      const d = this._drag;
+      const x = Math.min(d.x0, d.x1) * 100, y = Math.min(d.y0, d.y1) * 100;
+      const w = Math.abs(d.x1 - d.x0) * 100, h = Math.abs(d.y1 - d.y0) * 100;
+      parts.push(`<rect class="draft" x="${x}%" y="${y}%" width="${w}%" height="${h}%" />`);
+    }
+    this._els.overlay.innerHTML = parts.join("");
+  }
+
+  // --- dispatch ------------------------------------------------------------------------------
+  async _clean() {
+    if (!this._hass || this._zones.length === 0) return;
+    const zones = this._zones.map((z) => [z.x0, z.y0, z.x1, z.y1]);
+    const n = zones.length;
+    this._els.clean.disabled = true;
+    try {
+      await this._hass.callService("vacuum", "send_command", {
+        entity_id: this._config.vacuum,
+        command: "zone_clean",
+        params: { zones, clean_times: this._cleanTimes },
+      });
+      this._zones = [];
+      this._renderOverlay();
+      this._setStatus(`Sent ${n} zone${n > 1 ? "s" : ""} • passes ${this._cleanTimes}`);
+    } catch (err) {
+      this._setStatus(`Failed: ${err && err.message ? err.message : err}`);
+    }
+    this._syncControls();
+  }
+
+  static getStubConfig(hass) {
+    const states = (hass && hass.states) || {};
+    const pick = (domain, pred) =>
+      Object.keys(states).find((e) => e.startsWith(domain + ".") && (!pred || pred(e)));
+    const vacuum = pick("vacuum") || "vacuum.robot";
+    const camera = pick("camera", (e) => e.endsWith("_map")) || pick("camera") || "camera.robot_map";
+    return { vacuum, camera }; // selects auto-discovered from the vacuum slug
+  }
+
+  static getConfigElement() {
+    return document.createElement("zone-clean-card-editor");
+  }
+}
+
+customElements.define("zone-clean-card", ZoneCleanCard);
+
+/* ------------------------------------------------------------------------------------------
+ * Visual config editor — vanilla, no Lit, no dependencies. Renders in the dashboard card
+ * editor so you can pick entities by clicking instead of writing YAML.
+ * ---------------------------------------------------------------------------------------- */
+class ZoneCleanCardEditor extends HTMLElement {
+  setConfig(config) {
+    this._config = Object.assign({}, config);
+    if (this._built && !this._emitting) this._fill();
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    if (!this._built) this._build();
+  }
+
+  _list(domain) {
+    const s = (this._hass && this._hass.states) || {};
+    return Object.keys(s).filter((e) => e.startsWith(domain + ".")).sort();
+  }
+
+  _build() {
+    if (!this._hass || !this._config) return;
+    const opt = (list, sel) =>
+      ['<option value="">— choose —</option>']
+        .concat(list.map((e) => `<option value="${e}"${e === sel ? " selected" : ""}>${e}</option>`))
+        .join("");
+    const picks = this._list("select");
+    this.innerHTML = `
+      <style>
+        .zcce { display: flex; flex-direction: column; gap: 12px; padding: 4px 2px; }
+        .zcce label.fld { font-size: 0.85rem; font-weight: 500; display: block; margin-bottom: 2px; }
+        .zcce select, .zcce input[type=text] { width: 100%; padding: 7px 8px; box-sizing: border-box;
+          border: 1px solid var(--divider-color, #ccc); border-radius: 6px;
+          background: var(--card-background-color, #fff); color: var(--primary-text-color, #000); }
+        .zcce .hint { font-size: 0.75rem; color: var(--secondary-text-color, #888); margin-top: 2px; }
+        .zcce .picks { display: flex; flex-direction: column; gap: 4px; max-height: 180px; overflow: auto;
+          border: 1px solid var(--divider-color, #ccc); border-radius: 6px; padding: 8px; }
+        .zcce .picks label { font-weight: 400; font-size: 0.85rem; display: flex; gap: 8px; align-items: center; margin: 0; }
+      </style>
+      <div class="zcce">
+        <div><label class="fld">Vacuum (required)</label>
+          <select class="f-vacuum">${opt(this._list("vacuum"), this._config.vacuum)}</select></div>
+        <div><label class="fld">Map camera (required)</label>
+          <select class="f-camera">${opt(this._list("camera"), this._config.camera)}</select></div>
+        <div><label class="fld">Title</label>
+          <input type="text" class="f-title" placeholder="Zone Clean" value="${(this._config.title || "").replace(/"/g, "&quot;")}" /></div>
+        <div>
+          <label class="fld">Setting selects</label>
+          <div class="picks">${
+            picks.map((e) => {
+              const on = (this._config.selects || []).includes(e);
+              return `<label><input type="checkbox" value="${e}"${on ? " checked" : ""}/> ${e}</label>`;
+            }).join("") || '<span class="hint">No select entities found.</span>'
+          }</div>
+          <div class="hint">Leave all unchecked to auto-discover the vacuum's selects.</div>
+        </div>
+      </div>
+    `;
+    this.querySelector(".f-vacuum").addEventListener("change", () => this._changed());
+    this.querySelector(".f-camera").addEventListener("change", () => this._changed());
+    this.querySelector(".f-title").addEventListener("input", () => this._changed());
+    this.querySelectorAll(".picks input[type=checkbox]").forEach((cb) =>
+      cb.addEventListener("change", () => this._changed())
+    );
+    this._built = true;
+  }
+
+  _fill() {
+    const v = this.querySelector(".f-vacuum"); if (v) v.value = this._config.vacuum || "";
+    const c = this.querySelector(".f-camera"); if (c) c.value = this._config.camera || "";
+    // title + checkboxes intentionally left untouched to avoid cursor/scroll jumps
+  }
+
+  _changed() {
+    const val = (q) => { const el = this.querySelector(q); return el ? el.value : ""; };
+    const cfg = Object.assign({}, this._config);
+    cfg.vacuum = val(".f-vacuum");
+    cfg.camera = val(".f-camera");
+    const t = val(".f-title").trim();
+    if (t) cfg.title = t; else delete cfg.title;
+    const checked = Array.from(this.querySelectorAll(".picks input:checked")).map((c) => c.value);
+    if (checked.length) cfg.selects = checked; else delete cfg.selects;
+    this._config = cfg;
+    this._emitting = true;
+    this.dispatchEvent(new CustomEvent("config-changed", { detail: { config: cfg }, bubbles: true, composed: true }));
+    this._emitting = false;
+  }
+}
+customElements.define("zone-clean-card-editor", ZoneCleanCardEditor);
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+  type: "zone-clean-card",
+  name: "Zone Clean Card",
+  description: "Draw zones on the live map and clean them (Eufy — smcneece/jeppesens eufy-clean).",
+});
+console.info("%c ZONE-CLEAN-CARD %c standalone ", "background:#3b82f6;color:#fff;border-radius:3px 0 0 3px;padding:2px 4px", "background:#222;color:#fff;border-radius:0 3px 3px 0;padding:2px 4px");

--- a/custom_components/robovac_mqtt/manifest.json
+++ b/custom_components/robovac_mqtt/manifest.json
@@ -7,7 +7,6 @@
   ],
   "config_flow": true,
   "dependencies": [
-    "frontend",
     "http"
   ],
   "documentation": "https://github.com/jeppesens/eufy-clean",

--- a/custom_components/robovac_mqtt/manifest.json
+++ b/custom_components/robovac_mqtt/manifest.json
@@ -6,7 +6,10 @@
     "@m11tch"
   ],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": [
+    "frontend",
+    "http"
+  ],
   "documentation": "https://github.com/jeppesens/eufy-clean",
   "integration_type": "device",
   "iot_class": "cloud_push",

--- a/custom_components/robovac_mqtt/vacuum.py
+++ b/custom_components/robovac_mqtt/vacuum.py
@@ -367,6 +367,42 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
         # 1. Start Clean with GENERAL Mode
         await self._async_send_room_clean(room_ids, map_id)
 
+    async def _async_handle_zone_clean(self, params: dict[str, Any]) -> None:
+        """Handle a zone_clean command.
+
+        ``params['zones']`` is a list of normalized rectangles ``(x0, y0, x1, y1)``
+        in fractions (0-1) of the rendered map image.  They are converted to
+        world-cm quadrilaterals against the current map and dispatched as a
+        select-zones clean (mirrors ``_async_handle_room_clean``).
+        """
+        rects = params.get("zones") or params.get("rects")
+        if not rects or not isinstance(rects, list):
+            _LOGGER.warning("zone_clean called without a 'zones' list of rectangles")
+            return
+
+        quads_cm = self.coordinator.normalized_rects_to_quads_cm(rects)
+        if not quads_cm:
+            _LOGGER.warning(
+                "zone_clean: no map available yet (run a clean once so the map "
+                "populates) or all rectangles were invalid — nothing sent"
+            )
+            return
+
+        map_id = params.get("map_id") or self.coordinator.data.map_id or 1
+        clean_times = int(params.get("clean_times", 1))
+
+        command = build_command(
+            "zone_clean",
+            zones_cm=quads_cm,
+            map_id=map_id,
+            clean_times=clean_times,
+        )
+        if not command:
+            return
+
+        self.coordinator.set_active_cleaning_targets(zone_count=len(quads_cm))
+        await self.coordinator.async_send_command(command)
+
     async def async_clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:
         """Clean specific segments with current custom parameters."""
         room_ids = [
@@ -544,6 +580,10 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
 
         if command == "room_clean" and isinstance(params, dict):
             await self._async_handle_room_clean(params)
+            return
+
+        if command == "zone_clean" and isinstance(params, dict):
+            await self._async_handle_zone_clean(params)
             return
 
         # Handle Apple Home app_segment_clean command

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -15,9 +15,15 @@ from custom_components.robovac_mqtt.api.commands import (
     build_set_volume_command,
     build_set_volume_novel_command,
     build_set_water_level_command,
+    build_zone_clean_command,
 )
 from custom_components.robovac_mqtt.api.parser import _extract_off_peak_charging
-from custom_components.robovac_mqtt.const import DPS_MAP, SCALAR_DPS
+from custom_components.robovac_mqtt.const import (
+    DPS_MAP,
+    EUFY_CLEAN_CONTROL,
+    SCALAR_DPS,
+)
+from custom_components.robovac_mqtt.proto.cloud.control_pb2 import ModeCtrlRequest
 from custom_components.robovac_mqtt.proto.cloud.unisetting_pb2 import UnisettingRequest
 from custom_components.robovac_mqtt.utils import decode, decode_varint, encode_varint
 
@@ -69,6 +75,49 @@ def test_set_child_lock_command():
     assert DPS_MAP["UNSETTING"] in result
     decoded = decode(UnisettingRequest, result[DPS_MAP["UNSETTING"]])
     assert decoded.children_lock.value is True
+
+
+# ── zone (select-zones) clean ────────────────────────────────────────
+
+
+def test_build_zone_clean_command():
+    """Zone clean encodes a SelectZonesClean ModeCtrlRequest on DPS 152."""
+    quad = [(100, 200), (500, 200), (500, 600), (100, 600)]
+    result = build_zone_clean_command([quad], map_id=3, clean_times=2)
+
+    assert DPS_MAP["PLAY_PAUSE"] in result
+    decoded = decode(ModeCtrlRequest, result[DPS_MAP["PLAY_PAUSE"]])
+    assert decoded.method == EUFY_CLEAN_CONTROL.START_SELECT_ZONES_CLEAN
+    assert decoded.WhichOneof("Param") == "select_zones_clean"
+    szc = decoded.select_zones_clean
+    assert szc.map_id == 3
+    assert len(szc.zones) == 1
+    zone = szc.zones[0]
+    assert zone.clean_times == 2
+    q = zone.quadrangle
+    got = [(q.p0.x, q.p0.y), (q.p1.x, q.p1.y), (q.p2.x, q.p2.y), (q.p3.x, q.p3.y)]
+    assert got == quad
+
+
+def test_build_zone_clean_command_empty():
+    """No zones -> empty dict (nothing dispatched)."""
+    assert not build_zone_clean_command([])
+
+
+def test_build_zone_clean_command_skips_bad_quad():
+    """A quad without exactly four corners is skipped (no zones left -> empty)."""
+    assert not build_zone_clean_command([[(0, 0), (1, 1)]])
+
+
+def test_build_command_zone_clean_dispatch():
+    """build_command routes 'zone_clean' to the zone builder."""
+    quad = [(0, 0), (10, 0), (10, 10), (0, 10)]
+    result = build_command("zone_clean", zones_cm=[quad], map_id=1)
+
+    assert DPS_MAP["PLAY_PAUSE"] in result
+    decoded = decode(ModeCtrlRequest, result[DPS_MAP["PLAY_PAUSE"]])
+    assert decoded.method == EUFY_CLEAN_CONTROL.START_SELECT_ZONES_CLEAN
+    assert decoded.select_zones_clean.map_id == 1
 
 
 # ── G-series scalar command builders (T2210/G50) ─────────────────────

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
+from custom_components.robovac_mqtt.api.map_stream import MapData
 from custom_components.robovac_mqtt.coordinator import EufyCleanCoordinator
 from custom_components.robovac_mqtt.models import VacuumState
 
@@ -47,6 +48,70 @@ def test_coordinator_init(mock_hass, mock_login):
         # Verify initial DPS processing
         mock_update.assert_called_once()
         assert coordinator.data.battery_level == 100
+
+
+def _coordinator_with_map(mock_hass, mock_login, map_data):
+    """Build a coordinator and pin its decoded map data (skips MQTT)."""
+    device_info = {
+        "deviceId": "test_id",
+        "deviceModel": "T2118",
+        "deviceName": "Test Vac",
+        "dps": {},
+    }
+    with patch(
+        "custom_components.robovac_mqtt.coordinator.update_state"
+    ) as mock_update:
+        mock_update.return_value = (VacuumState(), {})
+        coordinator = EufyCleanCoordinator(mock_hass, mock_login, device_info)
+    coordinator._map_data = map_data  # pylint: disable=protected-access
+    return coordinator
+
+
+def test_normalized_rects_to_quads_cm_no_map(mock_hass, mock_login):
+    """With no map decoded yet, the helper returns [] so callers no-op."""
+    coordinator = _coordinator_with_map(mock_hass, mock_login, None)
+    assert not coordinator.normalized_rects_to_quads_cm([(0.0, 0.0, 1.0, 1.0)])
+
+
+def test_normalized_rects_to_quads_cm_orientation(mock_hass, mock_login):
+    """A normalized rect maps to a world-cm rectangle with the Y-flip baked in."""
+    md = MapData(
+        raw_pixels=b"",
+        width=400,
+        height=300,
+        origin_x=-1500,
+        origin_y=-1000,
+        resolution=5,
+    )
+    coordinator = _coordinator_with_map(mock_hass, mock_login, md)
+
+    quads = coordinator.normalized_rects_to_quads_cm([(0.0, 0.0, 1.0, 1.0)])
+    assert len(quads) == 1
+    tl, tr, br, bl = quads[0]
+
+    # Axis-aligned rectangle.
+    assert tl[0] == bl[0] and tr[0] == br[0]
+    assert tl[1] == tr[1] and bl[1] == br[1]
+    # X grows left->right across the image.
+    assert tl[0] < tr[0]
+    # World Y DECREASES top->bottom of the image (render Y-flip).
+    assert tl[1] > bl[1]
+    # Exact spot-check of the unambiguous top-left corner
+    # (nx=0 -> origin_x; ny=0 -> origin_y + (height-1)*res).
+    assert tl == (-1500, -1000 + (300 - 1) * 5)
+
+
+def test_normalized_rects_to_quads_cm_skips_malformed(mock_hass, mock_login):
+    """A rect that isn't four numbers is skipped; valid ones still convert."""
+    md = MapData(
+        raw_pixels=b"", width=100, height=100, origin_x=0, origin_y=0, resolution=10
+    )
+    coordinator = _coordinator_with_map(mock_hass, mock_login, md)
+
+    quads = coordinator.normalized_rects_to_quads_cm(
+        [(0.0, 0.0, 0.5), (0.0, 0.0, 0.5, 0.5)]  # first has only 3 values
+    )
+    assert len(quads) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,6 +8,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.robovac_mqtt import _async_register_frontend_card
 from custom_components.robovac_mqtt.const import DOMAIN
 
 
@@ -82,3 +83,37 @@ async def test_load_unload_entry(hass: HomeAssistant):
         assert (
             config_entry.state == ConfigEntryState.NOT_LOADED
         ), f"Entry state {config_entry.state}, expected {ConfigEntryState.NOT_LOADED}"
+
+
+async def test_bundled_zone_clean_card_registered(hass: HomeAssistant):
+    """The bundled zone-clean Lovelace card is served + registered exactly once."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_USERNAME: "test_user",
+            CONF_PASSWORD: "test_password",
+        },
+        entry_id="card_entry_id",
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch("custom_components.robovac_mqtt.EufyLogin") as mock_login_cls, patch(
+        "custom_components.robovac_mqtt.add_extra_js_url"
+    ) as mock_add_js:
+        mock_login = mock_login_cls.return_value
+        mock_login.init = AsyncMock()
+        mock_login.mqtt_devices = []  # card registration is independent of devices
+
+        result = await hass.config_entries.async_setup(config_entry.entry_id)
+        assert result is True, f"Async setup failed, result: {result}"
+        await hass.async_block_till_done()
+
+        # Registered once, with a cache-busted URL pointing at the bundled file.
+        assert hass.data[DOMAIN]["card_registered"] is True
+        mock_add_js.assert_called_once()
+        registered_url = mock_add_js.call_args.args[1]
+        assert registered_url.startswith("/robovac_mqtt/zone-clean-card.js?v=")
+
+        # Idempotent: the once-guard holds, so a second pass does nothing.
+        await _async_register_frontend_card(hass)
+        mock_add_js.assert_called_once()

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -118,6 +118,56 @@ async def test_vacuum_commands(mock_coordinator, mock_config_entry):
 
 
 @pytest.mark.asyncio
+async def test_zone_clean_dispatch(mock_coordinator, mock_config_entry):
+    """zone_clean converts normalized rects, marks zone targets, and dispatches."""
+    entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
+    quads = [[(1, 2), (3, 2), (3, 4), (1, 4)]]
+    mock_coordinator.normalized_rects_to_quads_cm = MagicMock(return_value=quads)
+    mock_coordinator.set_active_cleaning_targets = MagicMock()
+    mock_coordinator.data.map_id = 3
+
+    with patch("custom_components.robovac_mqtt.vacuum.build_command") as mock_build:
+        mock_build.return_value = {"152": "encoded"}
+        await entity.async_send_command(
+            "zone_clean", {"zones": [[0.1, 0.2, 0.3, 0.4]]}
+        )
+
+    mock_coordinator.normalized_rects_to_quads_cm.assert_called_once_with(
+        [[0.1, 0.2, 0.3, 0.4]]
+    )
+    mock_build.assert_called_once_with(
+        "zone_clean", zones_cm=quads, map_id=3, clean_times=1
+    )
+    mock_coordinator.set_active_cleaning_targets.assert_called_once_with(zone_count=1)
+    mock_coordinator.async_send_command.assert_called_with({"152": "encoded"})
+
+
+@pytest.mark.asyncio
+async def test_zone_clean_no_rects_noop(mock_coordinator, mock_config_entry):
+    """zone_clean with an empty 'zones' list dispatches nothing."""
+    entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
+    mock_coordinator.normalized_rects_to_quads_cm = MagicMock(return_value=[])
+
+    await entity.async_send_command("zone_clean", {"zones": []})
+
+    mock_coordinator.async_send_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_zone_clean_no_map_noop(mock_coordinator, mock_config_entry):
+    """zone_clean before the map has loaded (helper returns []) dispatches nothing."""
+    entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
+    mock_coordinator.normalized_rects_to_quads_cm = MagicMock(return_value=[])
+
+    await entity.async_send_command(
+        "zone_clean", {"zones": [[0.1, 0.2, 0.3, 0.4]]}
+    )
+
+    mock_coordinator.normalized_rects_to_quads_cm.assert_called_once()
+    mock_coordinator.async_send_command.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_set_fan_speed(mock_coordinator, mock_config_entry):
     """Test setting fan speed."""
     entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)


### PR DESCRIPTION
## What

Adds a `zone_clean` `vacuum.send_command` that runs a **select-zones clean** — "draw a box on the map and clean just that area."

This builds on the `SelectZonesClean` machinery that's **already in the integration** — the proto message, the `START_SELECT_ZONES_CLEAN` method, the parser that decodes `select_zones_clean` into `active_zone_count`, and the `active_zone_count` attribute — but which so far had **no way to start a zone clean** (`build_command` only dispatched room / spot / scene cleans). This wires up the missing trigger.

```yaml
service: vacuum.send_command
target:
  entity_id: vacuum.robot
data:
  command: zone_clean
  params:
    zones: [[0.10, 0.12, 0.42, 0.55]]   # normalized 0-1 rects of the rendered map image
    clean_times: 1                        # optional (default 1)
```

## How

- **`build_zone_clean_command(zones_cm, map_id, clean_times)`** (`api/commands.py`) — encodes a `ModeCtrlRequest` with method `START_SELECT_ZONES_CLEAN` carrying a `SelectZonesClean` of `Quadrangle` zones on DPS 152. Same dispatch shape as `build_room_clean_command`; malformed quads are skipped, an empty list is a no-op.
- **`normalized_rects_to_quads_cm(rects)`** (`coordinator.py`) — converts the caller's **normalized (0-1)** image rects into the device's **world-cm** quadrilaterals by inverting the map render's affine (origin + resolution + image size) from the live map. Returns `[]` when no map is available yet, so a too-early call no-ops instead of mis-targeting.
- **`_async_handle_zone_clean(params)`** (`vacuum.py`) — the `send_command` handler: normalized rects → cm quads → dispatch, mirroring `_async_handle_room_clean`.

Callers send **normalized** rects (fractions of the rendered map image); all device-coordinate math stays server-side, so any front end — a Lovelace card, an automation — only needs the image fraction.

## Notes

- **Validated live** on a Eufy X-series (X10). Uses the same `ModeCtrlRequest` / DPS-152 path as room cleaning, so it should work on any novel-protocol device that supports select-zones clean.
- **Tested**: new unit tests for the builder (encode/decode round-trip + `build_command` dispatch), the coordinate conversion, and the handler (`tests/test_commands.py`, `tests/test_coordinator.py`, `tests/test_vacuum.py`). Full suite green; flake8 + isort (black profile) clean.
- No new dependencies; no change to existing behavior.
