### PR TITLE
fix: register the bundled card when frontend is ready (fixes #140)

### DIFF
--- a/custom_components/robovac_mqtt/__init__.py
+++ b/custom_components/robovac_mqtt/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.loader import async_get_integration
+from homeassistant.setup import async_when_setup
 
 from .api.cloud import EufyLogin
 from .const import DOMAIN
@@ -52,10 +53,11 @@ async def _async_register_frontend_card(hass: HomeAssistant) -> None:
     # ?v=<version> busts the browser cache whenever the integration updates.
     card_url = f"{_CARD_URL_PATH}?v={integration.version}"
 
-    # The card is a best-effort enhancement. In a normal install the frontend is
-    # already set up by the time this entry loads, but we don't declare it as a
-    # hard dependency: a not-yet-ready (or headless) frontend must never fail the
-    # vacuum integration's setup. add_extra_js_url needs the frontend in place.
+    # Runs from async_when_setup(hass, "frontend", ...), so frontend is set up and
+    # add_extra_js_url's hass.data is in place. We still don't declare a hard
+    # `frontend` dependency (headless installs must load without it); the try/except
+    # stays as a belt-and-suspenders guard so an optional card can never fail the
+    # vacuum integration's setup.
     try:
         await hass.http.async_register_static_paths(
             [
@@ -77,12 +79,24 @@ async def _async_register_frontend_card(hass: HomeAssistant) -> None:
     _LOGGER.debug("Registered bundled Eufy Clean card at %s", card_url)
 
 
+async def _register_card_when_frontend_ready(
+    hass: HomeAssistant, _component: str
+) -> None:
+    """``async_when_setup`` callback — register the card now that frontend is up."""
+    await _async_register_frontend_card(hass)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Initialize the integration."""
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
-    # Serve + register the bundled zone-clean Lovelace card (once across entries).
-    await _async_register_frontend_card(hass)
+    # Register the bundled card once `frontend` is set up. async_when_setup fires
+    # immediately if it already is, else when it finishes — so the card registers
+    # regardless of integration load order. Calling _async_register_frontend_card
+    # directly here silently no-ops when this entry loads before frontend (the
+    # add_extra_js_url hass.data isn't there yet), which is why the card was missing
+    # on some installs (issue #140).
+    async_when_setup(hass, "frontend", _register_card_when_frontend_ready)
 
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,7 +8,6 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.robovac_mqtt import _async_register_frontend_card
 from custom_components.robovac_mqtt.const import DOMAIN
 
 
@@ -86,7 +85,7 @@ async def test_load_unload_entry(hass: HomeAssistant):
 
 
 async def test_bundled_eufy_clean_card_registered(hass: HomeAssistant):
-    """The bundled Eufy Clean Lovelace card is served + registered exactly once."""
+    """The bundled card registers once `frontend` is set up (load-order safe)."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -97,9 +96,16 @@ async def test_bundled_eufy_clean_card_registered(hass: HomeAssistant):
     )
     config_entry.add_to_hass(hass)
 
+    when_setup_calls: list = []
+
+    def fake_when_setup(_hass, component, callback):
+        when_setup_calls.append((component, callback))
+
     with patch("custom_components.robovac_mqtt.EufyLogin") as mock_login_cls, patch(
         "custom_components.robovac_mqtt.add_extra_js_url"
-    ) as mock_add_js:
+    ) as mock_add_js, patch(
+        "custom_components.robovac_mqtt.async_when_setup", side_effect=fake_when_setup
+    ):
         mock_login = mock_login_cls.return_value
         mock_login.init = AsyncMock()
         mock_login.mqtt_devices = []  # card registration is independent of devices
@@ -108,12 +114,21 @@ async def test_bundled_eufy_clean_card_registered(hass: HomeAssistant):
         assert result is True, f"Async setup failed, result: {result}"
         await hass.async_block_till_done()
 
-        # Registered once, with a cache-busted URL pointing at the bundled file.
+        # Registration is DEFERRED to the frontend component, not done inline — this
+        # is what prevents the load-order race (entry set up before frontend) that
+        # left the card unregistered on some installs (#140).
+        assert len(when_setup_calls) == 1
+        component, register_cb = when_setup_calls[0]
+        assert component == "frontend"
+        mock_add_js.assert_not_called()  # nothing registered until frontend is up
+
+        # Frontend becomes ready -> the card registers once, with a cache-bust URL.
+        await register_cb(hass, "frontend")
         assert hass.data[DOMAIN]["card_registered"] is True
         mock_add_js.assert_called_once()
         registered_url = mock_add_js.call_args.args[1]
         assert registered_url.startswith("/robovac_mqtt/eufy-clean-card.js?v=")
 
-        # Idempotent: the once-guard holds, so a second pass does nothing.
-        await _async_register_frontend_card(hass)
+        # Idempotent: a second frontend-ready callback does nothing.
+        await register_cb(hass, "frontend")
         mock_add_js.assert_called_once()


### PR DESCRIPTION
## Problem

On installs where this integration's config entry is set up **before** the `frontend` component, the bundled card silently never registers — the dashboard shows `Custom element not found: zone-clean-card` even though the integration (and its map camera) load fine. Reported in #140 (persisted across a re-download, an HA restart, and v1.11.2-beta1, on desktop + a fresh phone — ruling out client caching).

Root cause: `async_setup_entry` registers the card inline via `add_extra_js_url`, which does `hass.data[DATA_EXTRA_MODULE_URL].add(url)`. That key only exists once `frontend` has set up. With `dependencies: ["http"]` (no `frontend`), HA does not guarantee `frontend` loads first, so on the losing side of that race `add_extra_js_url` raises `KeyError`, the best-effort `except` swallows it (`"Could not register the bundled Eufy Clean card; skipping"`), and the card is never served. Load order is stable per-install, so an affected user hits it every boot.

## Fix

Defer registration until `frontend` is ready, via `async_when_setup(hass, "frontend", …)` — it fires the moment `frontend` is set up (immediately if it already is), so registration happens regardless of integration load order. No hard `frontend` dependency is added, so a headless / frontend-less CI still loads the entry.

`test_init` is updated to assert the new behavior: registration is deferred to the `frontend` component (not done inline), nothing registers until it fires, and the callback then registers the card exactly once (idempotent).

Verified locally in a Linux container matching CI (Python 3.14, `requirements_test.txt`): `pytest` green and `pre-commit` (pyupgrade / codespell / flake8 / isort / mypy / pylint) all pass.

Fixes #140.
