### PR TITLE
fix(#121/#124): prefer a login that yields a user_center token

### DIFF
--- a/custom_components/robovac_mqtt/api/http.py
+++ b/custom_components/robovac_mqtt/api/http.py
@@ -180,20 +180,21 @@ class EufyHTTPClient:
             },
         ) as response:
             if response.status == 200:
-                self.user_info = await response.json()
-                if self.user_info is None or not self.user_info.get(
-                    "user_center_id"
-                ):
+                user_info = await response.json()
+                if user_info is None or not user_info.get("user_center_id"):
                     _LOGGER.error("No user_center_id found")
+                    self.user_info = None
                     return None
 
                 # Generate GToken
-                self.user_info["gtoken"] = hashlib.md5(
-                    self.user_info["user_center_id"].encode()
+                user_info["gtoken"] = hashlib.md5(
+                    user_info["user_center_id"].encode()
                 ).hexdigest()
+                self.user_info = user_info
                 return self.user_info
 
             _LOGGER.error("get user center info failed")
+            self.user_info = None
             return None
 
     async def get_device_list(self) -> list[dict[str, Any]]:

--- a/custom_components/robovac_mqtt/api/http.py
+++ b/custom_components/robovac_mqtt/api/http.py
@@ -59,69 +59,107 @@ class EufyHTTPClient:
         self.user_info: dict[str, Any] | None = None
 
     async def login(self, validate_only: bool = False) -> dict[str, Any]:
-        """Perform login flow."""
-        session = await self.eufy_login()
-        if not session:
-            return {}
+        """Log in, preferring a credential set whose token yields a user_center id.
 
-        if validate_only:
-            return {"session": session}
-
-        user = await self.get_user_info()
-        mqtt = await self.get_mqtt_credentials()
-        return {"session": session, "user": user, "mqtt": mqtt}
-
-    async def eufy_login(self) -> dict[str, Any] | None:
-        """Login to Eufy Cloud. Tries v2 (new Eufy app) first, falls back to v1."""
-        session = self._websession
-        last_error: str | None = None
-
+        AIOT/MQTT discovery (get_device_list, get_mqtt_credentials) needs a
+        ``user_center_token``, which some accounts — notably ones migrated to the
+        new unified Eufy app — only obtain from the v2 ``eufy-app`` login; the v1
+        token authenticates but returns no user_center (issues #121/#124/#131).
+        So rather than use the FIRST login that returns an access_token, try each
+        and prefer one whose token actually yields a ``user_center_id``. Fall
+        back to any working token — the Tuya cloud path only needs the eufy
+        ``user_id``.
+        """
+        fallback_session: dict[str, Any] | None = None
         for config in _LOGIN_CONFIGS:
-            _LOGGER.debug(
-                "Attempting login via %s: %s", config["label"], config["url"]
-            )
-            async with session.post(
-                config["url"],
-                timeout=_REQUEST_TIMEOUT,
-                headers={
-                    "category": config["category"],
-                    "Accept": "*/*",
-                    "openudid": self.openudid,
-                    "Content-Type": "application/json",
-                    "clientType": "1",
-                    "User-Agent": "EufyHome-Android-3.1.3-753",
-                    "Connection": "keep-alive",
-                },
-                json={
-                    "email": self.username,
-                    "password": self.password,
-                    "client_id": config["client_id"],
-                    "client_secret": config["client_secret"],
-                },
-            ) as response:
-                response_json = None
-                try:
-                    response_json = await response.json()
-                except Exception:
-                    pass
+            session = await self._attempt_login(config)
+            if not session:
+                continue
+            self.session = session
+            if validate_only:
+                _LOGGER.info("Login (validate) successful via %s", config["label"])
+                return {"session": session}
 
-                if response.status == 200 and response_json:
-                    if response_json.get("access_token"):
-                        _LOGGER.info("Login successful via %s", config["label"])
-                        self.session = response_json
-                        return response_json
-
-                body = response_json or await response.text()
-                last_error = f"{config['label']}: {response.status} {body}"
-                _LOGGER.debug(
-                    "Login attempt failed for %s: %s %s",
+            user = await self.get_user_info()  # sets self.user_info
+            if user and user.get("user_center_id"):
+                _LOGGER.info(
+                    "Login successful via %s (user_center available)",
                     config["label"],
-                    response.status,
-                    body,
                 )
+                mqtt = await self.get_mqtt_credentials()
+                return {"session": session, "user": user, "mqtt": mqtt}
 
-        _LOGGER.error("All login attempts failed. Last error: %s", last_error)
-        return None
+            _LOGGER.debug(
+                "Login via %s yielded no user_center; keeping as fallback and "
+                "trying the next credential set",
+                config["label"],
+            )
+            if fallback_session is None:
+                fallback_session = session
+
+        if fallback_session is not None:
+            # No login produced a user_center id (e.g. user_center_info returns
+            # 401 for this account). Use the fallback so the Tuya cloud/local
+            # path can still discover the device via the eufy user_id.
+            _LOGGER.info(
+                "No user_center from any login; using fallback session "
+                "(Tuya cloud/local discovery only)"
+            )
+            self.session = fallback_session
+            self.user_info = None
+            return {"session": fallback_session, "user": None, "mqtt": None}
+
+        _LOGGER.error("All login attempts failed.")
+        return {}
+
+    async def _attempt_login(
+        self, config: dict[str, str]
+    ) -> dict[str, Any] | None:
+        """POST a single credential set; return the session JSON or None."""
+        _LOGGER.debug(
+            "Attempting login via %s: %s", config["label"], config["url"]
+        )
+        session = self._websession
+        async with session.post(
+            config["url"],
+            timeout=_REQUEST_TIMEOUT,
+            headers={
+                "category": config["category"],
+                "Accept": "*/*",
+                "openudid": self.openudid,
+                "Content-Type": "application/json",
+                "clientType": "1",
+                "User-Agent": "EufyHome-Android-3.1.3-753",
+                "Connection": "keep-alive",
+            },
+            json={
+                "email": self.username,
+                "password": self.password,
+                "client_id": config["client_id"],
+                "client_secret": config["client_secret"],
+            },
+        ) as response:
+            response_json = None
+            try:
+                response_json = await response.json()
+            except Exception:
+                pass
+
+            if (
+                response.status == 200
+                and response_json
+                and response_json.get("access_token")
+            ):
+                return response_json
+
+            body = response_json or await response.text()
+            _LOGGER.debug(
+                "Login attempt failed for %s: %s %s",
+                config["label"],
+                response.status,
+                body,
+            )
+            return None
 
     async def get_user_info(self) -> dict[str, Any] | None:
         """Get User details."""

--- a/custom_components/robovac_mqtt/manifest.json
+++ b/custom_components/robovac_mqtt/manifest.json
@@ -21,5 +21,5 @@
     "Pillow>=10.0.0",
     "tinytuya>=1.18.0,<2.0.0"
   ],
-  "version": "1.12.1-beta2"
+  "version": "1.12.0-beta2"
 }

--- a/custom_components/robovac_mqtt/manifest.json
+++ b/custom_components/robovac_mqtt/manifest.json
@@ -21,5 +21,5 @@
     "Pillow>=10.0.0",
     "tinytuya>=1.18.0,<2.0.0"
   ],
-  "version": "1.12.1-beta1"
+  "version": "1.12.1-beta2"
 }

--- a/custom_components/robovac_mqtt/manifest.json
+++ b/custom_components/robovac_mqtt/manifest.json
@@ -21,5 +21,5 @@
     "Pillow>=10.0.0",
     "tinytuya>=1.18.0,<2.0.0"
   ],
-  "version": "1.12.0"
+  "version": "1.12.1-beta1"
 }

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -149,22 +149,21 @@ def _login_response(status: int, token: str | None = None) -> AsyncMock:
 
 
 @pytest.mark.asyncio
-async def test_eufy_login_succeeds_via_v2():
+async def test_login_validate_prefers_v2():
     """v2 (unified Eufy app) login is tried first; success short-circuits v1."""
     mock_session = _mock_websession_sequence(_login_response(200, "tok_v2"))
     client = _make_client(websession=mock_session)
 
-    result = await client.eufy_login()
+    result = await client.login(validate_only=True)
 
-    assert result is not None
-    assert result["access_token"] == "tok_v2"
+    assert result["session"]["access_token"] == "tok_v2"
     assert mock_session.post.call_count == 1
     first_url = mock_session.post.call_args_list[0][0][0]
     assert "v2/email/login" in first_url
 
 
 @pytest.mark.asyncio
-async def test_eufy_login_falls_back_to_v1():
+async def test_login_validate_falls_back_to_v1():
     """When v2 fails, v1 (legacy Eufy Clean app) is attempted and returned."""
     mock_session = _mock_websession_sequence(
         _login_response(401),            # v2 fails
@@ -172,25 +171,69 @@ async def test_eufy_login_falls_back_to_v1():
     )
     client = _make_client(websession=mock_session)
 
-    result = await client.eufy_login()
+    result = await client.login(validate_only=True)
 
-    assert result is not None
-    assert result["access_token"] == "tok_v1"
+    assert result["session"]["access_token"] == "tok_v1"
     assert mock_session.post.call_count == 2
 
 
 @pytest.mark.asyncio
-async def test_eufy_login_all_attempts_fail():
-    """Returns None when both v2 and v1 fail."""
+async def test_login_all_attempts_fail():
+    """Returns {} when both v2 and v1 fail."""
     mock_session = _mock_websession_sequence(
         _login_response(401), _login_response(403)
     )
     client = _make_client(websession=mock_session)
 
-    result = await client.eufy_login()
+    result = await client.login(validate_only=True)
 
-    assert result is None
+    assert result == {}
     assert mock_session.post.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_login_prefers_credential_with_user_center():
+    """When the first login authenticates but yields no user_center, login()
+    keeps trying and prefers a later credential set that does (issues
+    #121/#124/#131)."""
+    mock_session = _mock_websession_sequence(
+        _login_response(200, "tok_v2"),  # v2 authenticates...
+        _login_response(200, "tok_v1"),  # ...so does v1
+    )
+    client = _make_client(websession=mock_session)
+    # v2's token has no user_center; v1's does.
+    client.get_user_info = AsyncMock(
+        side_effect=[None, {"user_center_id": "x", "user_center_token": "t"}]
+    )
+    client.get_mqtt_credentials = AsyncMock(return_value={"endpoint": "mqtt"})
+
+    result = await client.login()
+
+    assert result["session"]["access_token"] == "tok_v1"
+    assert result["user"]["user_center_id"] == "x"
+    assert result["mqtt"] == {"endpoint": "mqtt"}
+    assert client.get_user_info.await_count == 2
+    client.get_mqtt_credentials.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_login_falls_back_when_no_user_center_anywhere():
+    """If no login yields a user_center, fall back to the first working token so
+    the Tuya cloud/local path can still discover via the eufy user_id."""
+    mock_session = _mock_websession_sequence(
+        _login_response(200, "tok_v2"),
+        _login_response(200, "tok_v1"),
+    )
+    client = _make_client(websession=mock_session)
+    client.get_user_info = AsyncMock(return_value=None)  # 401 -> no user_center
+    client.get_mqtt_credentials = AsyncMock(return_value={"endpoint": "mqtt"})
+
+    result = await client.login()
+
+    assert result["session"]["access_token"] == "tok_v2"  # first working token
+    assert result["user"] is None
+    assert result["mqtt"] is None
+    client.get_mqtt_credentials.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -237,6 +237,49 @@ async def test_login_falls_back_when_no_user_center_anywhere():
 
 
 @pytest.mark.asyncio
+async def test_login_real_sequence_v2_user_center_skips_v1():
+    """End-to-end (real get_user_info/gtoken): when the v2 login yields a
+    user_center, v1 is never attempted and MQTT creds are fetched."""
+
+    def _ctx(resp: AsyncMock) -> MagicMock:
+        c = MagicMock()
+        c.__aenter__ = AsyncMock(return_value=resp)
+        c.__aexit__ = AsyncMock(return_value=False)
+        return c
+
+    login_resp = _login_response(200, "tok_v2")
+    userinfo_resp = AsyncMock()
+    userinfo_resp.status = 200
+    userinfo_resp.json = AsyncMock(
+        return_value={"user_center_id": "uc1", "user_center_token": "uct"}
+    )
+    mqtt_resp = AsyncMock()
+    mqtt_resp.status = 200
+    mqtt_resp.json = AsyncMock(return_value={"data": {"endpoint": "mqtt"}})
+
+    mock_session = MagicMock()
+    mock_session.post.side_effect = [_ctx(login_resp), _ctx(mqtt_resp)]
+    mock_session.get.side_effect = [_ctx(userinfo_resp)]
+    client = _make_client(websession=mock_session)
+
+    result = await client.login()
+
+    assert result["session"]["access_token"] == "tok_v2"
+    assert result["user"]["user_center_id"] == "uc1"
+    assert result["user"]["gtoken"]  # real gtoken computed by get_user_info
+    assert result["mqtt"] == {"endpoint": "mqtt"}
+    assert client.user_info["user_center_id"] == "uc1"
+    # Only one login POST happened (v1 not attempted).
+    login_posts = [
+        c.args[0]
+        for c in mock_session.post.call_args_list
+        if "email/login" in c.args[0]
+    ]
+    assert len(login_posts) == 1
+    assert "v2/email/login" in login_posts[0]
+
+
+@pytest.mark.asyncio
 async def test_get_cloud_device_list_falls_back_to_home_api():
     """When the legacy device endpoint is empty, the home-api fallback is used."""
     legacy = AsyncMock()


### PR DESCRIPTION
Stacked on #110 (base: `feature/tuya-cloud-legacy-devices`). Addresses the "No devices" reports on unified-app accounts.

## Problem
AIOT device discovery (`get_device_list`) and `get_mqtt_credentials` require a `user_center_token` from `get_user_info()`. Some accounts — notably ones migrated to the new unified Eufy app — only obtain `user_center` from the **v2 `eufy-app`** login; the **v1** token authenticates but returns no `user_center`. The previous flow used the **first** login that returned an `access_token`, so these accounts ended up with an empty device list ("No devices") — see #121, #124, and jozesagan's notes on #131 (`user_center_info` returns 401).

## Change
- `login()` now tries each credential set and **prefers the first whose token yields a `user_center_id`** (then fetches MQTT creds).
- If none yields `user_center`, it **falls back** to any working token (`user=None`, `mqtt=None`) so the **Tuya cloud/local path** can still discover the device via the eufy `user_id`.
- `validate_only` still returns on the first working token.
- Split the per-attempt POST into `_attempt_login`; removed the now-unused `eufy_login` helper.

Cannot regress accounts that already work — their first/v2 login yields `user_center` and returns immediately (one `get_user_info` call, as before).

## Tests
515 pass on Python 3.14; flake8/mypy/pylint clean. New: `test_login_prefers_credential_with_user_center`, `test_login_falls_back_when_no_user_center_anywhere`; existing ordering tests repointed to `login()`.

## ⚠️ Needs real-device validation
I can't reproduce a migrated unified-app account locally. Asking the #121/#124 reporters to test this branch's beta and confirm their device is discovered.

#133/#143 (room-clean mode) will be added to this PR once the debug captures requested on those issues come back.
