### PR TITLE
feat(maps): add map_load service to switch the active map

### DIFF
--- a/custom_components/robovac_mqtt/api/commands.py
+++ b/custom_components/robovac_mqtt/api/commands.py
@@ -28,6 +28,7 @@ from ..proto.cloud.control_pb2 import (
     SelectZonesClean,
 )
 from ..proto.cloud.map_edit_pb2 import MapEditRequest
+from ..proto.cloud.multi_maps_pb2 import MultiMapsManageRequest
 from ..proto.cloud.station_pb2 import StationRequest
 from ..proto.cloud.undisturbed_pb2 import UndisturbedRequest
 from ..proto.cloud.unisetting_pb2 import UnisettingRequest
@@ -203,6 +204,36 @@ def build_zone_clean_command(
         )
     )
     return {DPS_MAP["PLAY_PAUSE"]: value}
+
+
+def build_map_load_command(cloud_mapid: int, seq: int = 1) -> dict[str, str]:
+    """Build a command to switch the active map to a saved multi-map by id.
+
+    Sends ``MultiMapsManageRequest{method=MAP_LOAD, common.cloud_mapid=<id>}`` on
+    the multi-map-manage DP (172). *cloud_mapid* is the saved map's id as reported
+    by the device (the ``map_id`` carried in incoming MAP_DATA); *seq* is an
+    arbitrary request sequence number the device echoes back in its ack.
+
+    NOTE — the robot pose does NOT switch automatically. Loading a map switches
+    the active map and its room list right away, but the robot's pose / coordinate
+    frame stays on the previous map until the vacuum RE-LOCALIZES, which only
+    happens once it MOVES. To ground the new map immediately after a switch, run a
+    small movement — a single-room clean (``room_clean`` / ``clean_segments``) is
+    the most reliable, since it targets a stable room id. Prefer starting it from a
+    script or the room LIST in the card; avoid coordinate-based targeting
+    (tap-a-room-on-the-map or zone drawing) until the frame re-grounds — the
+    transform is stale right after a switch. Once the robot moves, the reported
+    position snaps onto the loaded map.
+    """
+    if int(cloud_mapid) <= 0:
+        _LOGGER.warning("map_load ignored: cloud_mapid must be a positive map id")
+        return {}
+    req = MultiMapsManageRequest(
+        method=MultiMapsManageRequest.MAP_LOAD,
+        seq=int(seq),
+        common=MultiMapsManageRequest.Common(cloud_mapid=int(cloud_mapid)),
+    )
+    return {DPS_MAP["MULTI_MAP_MANAGE"]: encode_message(req)}
 
 
 def build_set_room_custom_command(
@@ -616,6 +647,11 @@ def build_command(
             kwargs.get("zones_cm", []),
             kwargs.get("map_id", 3),
             int(kwargs.get("clean_times", 1)),
+        )
+    if cmd == "map_load":
+        return build_map_load_command(
+            int(kwargs.get("cloud_mapid", 0)),
+            int(kwargs.get("seq", 1)),
         )
     if cmd == "set_room_custom":
         return build_set_room_custom_command(

--- a/custom_components/robovac_mqtt/api/map_stream.py
+++ b/custom_components/robovac_mqtt/api/map_stream.py
@@ -526,6 +526,27 @@ def try_extract_map_data(hex_data: str) -> MapData | None:
     )
 
 
+def try_extract_map_description(hex_data: str) -> tuple[int, str] | None:
+    """Extract ``(map_id, name)`` from a biz/ ``MapDescription`` frame, or None.
+
+    Each saved map's id and friendly name arrive over the cloud map stream as a
+    single-shot ``MapDescription`` when that map becomes active (e.g. after a map
+    switch). Other small biz/ frames (robot pose ``DynamicData``, ``RoomParams``)
+    can also decode without raising, so guard strictly: require a positive
+    ``map_id`` and a short, printable name. Used for map discovery (the Active Map
+    selector), which is why only id+name — not pixels — are returned.
+    """
+    try:
+        proto_bytes = _hex_to_proto_bytes(hex_data)
+        desc = stream_pb2.MapDescription().FromString(proto_bytes)
+    except Exception:
+        return None
+    name = desc.name
+    if desc.map_id > 0 and name and name.isprintable() and len(name) <= 48:
+        return desc.map_id, name
+    return None
+
+
 def try_decode_as_dynamic_data(hex_data: str) -> tuple[int, int, int] | None:
     """Decode channel as DynamicData robot pose. Returns (x_cm, y_cm, theta_crad) or None."""
     try:

--- a/custom_components/robovac_mqtt/api/map_stream.py
+++ b/custom_components/robovac_mqtt/api/map_stream.py
@@ -541,7 +541,10 @@ def try_extract_map_description(hex_data: str) -> tuple[int, str] | None:
         desc = stream_pb2.MapDescription().FromString(proto_bytes)
     except Exception:
         return None
-    name = desc.name
+    # Strip surrounding whitespace: renaming a map to a name Eufy considers
+    # "unchanged" is rejected, so users seed a name by adding a trailing space —
+    # keep the visible label clean.
+    name = desc.name.strip()
     if desc.map_id > 0 and name and name.isprintable() and len(name) <= 48:
         return desc.map_id, name
     return None

--- a/custom_components/robovac_mqtt/coordinator.py
+++ b/custom_components/robovac_mqtt/coordinator.py
@@ -401,19 +401,16 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
                     new_state, dock_status=effective_current_status
                 )
 
-                # Accumulate every visited map id so the Switch Map selector can
-                # switch to any map the robot has been on. map_id arrives reliably
-                # over this DPS path (the signal the Active Map sensor tracks); the
-                # friendly name is layered in from the biz MapDescription stream
-                # when seen, else the option shows as "Map (ID: <id>)".
-                if (
-                    "map_id" in changes
-                    and new_state.map_id
-                    and new_state.map_id > 0
-                    and new_state.map_id not in self.last_seen_maps
-                ):
-                    self.last_seen_maps[new_state.map_id] = ""
-                    self.hass.async_create_task(self.async_save_maps())
+                # Remember every visited map id so the Switch Map selector can switch
+                # to any map the robot has been on — including the one active at
+                # STARTUP, which never arrives as a map_id "change" and so was
+                # previously dropped from the selector until the robot switched to it
+                # again. Seeding the current map on every state (not only on a change)
+                # fixes that; the helper no-ops once the id is known, so it stays cheap.
+                # map_id rides this DPS path reliably (the signal the Active Map sensor
+                # tracks); the friendly name is layered in from the biz MapDescription
+                # stream when seen, else the option shows as "Map (ID: <id>)".
+                self._remember_map_id(new_state.map_id)
 
                 self.async_set_updated_data(state_to_publish)
 
@@ -962,6 +959,20 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
             len(segments_payload),
             self.device_name,
         )
+
+    def _remember_map_id(self, map_id: int | None) -> None:
+        """Record a visited map id into ``last_seen_maps`` (id-only; the friendly name
+        is layered in later from the biz ``MapDescription`` stream) and persist it.
+
+        The single path both a live DPS ``map_id`` change and the map active at startup
+        go through. The startup map never arrives as a "change", so seeding the current
+        map on every state is what keeps it in the Switch Map selector after switching
+        away. No-op for a missing / non-positive id or one already known, so it is cheap
+        to call on every state update.
+        """
+        if map_id and map_id > 0 and map_id not in self.last_seen_maps:
+            self.last_seen_maps[map_id] = ""
+            self.hass.async_create_task(self.async_save_maps())
 
     async def async_save_maps(self) -> None:
         """Persist discovered saved-map id→name to storage."""

--- a/custom_components/robovac_mqtt/coordinator.py
+++ b/custom_components/robovac_mqtt/coordinator.py
@@ -401,6 +401,20 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
                     new_state, dock_status=effective_current_status
                 )
 
+                # Accumulate every visited map id so the Switch Map selector can
+                # switch to any map the robot has been on. map_id arrives reliably
+                # over this DPS path (the signal the Active Map sensor tracks); the
+                # friendly name is layered in from the biz MapDescription stream
+                # when seen, else the option shows as "Map (ID: <id>)".
+                if (
+                    "map_id" in changes
+                    and new_state.map_id
+                    and new_state.map_id > 0
+                    and new_state.map_id not in self.last_seen_maps
+                ):
+                    self.last_seen_maps[new_state.map_id] = ""
+                    self.hass.async_create_task(self.async_save_maps())
+
                 self.async_set_updated_data(state_to_publish)
 
                 # Re-render now that self.data reflects the new activity/dock state.

--- a/custom_components/robovac_mqtt/coordinator.py
+++ b/custom_components/robovac_mqtt/coordinator.py
@@ -40,6 +40,7 @@ from .api.map_stream import (
     render_map_png,
     try_decode_as_dynamic_data,
     try_extract_map_data,
+    try_extract_map_description,
 )
 from .api.parser import update_state
 from .const import (
@@ -141,6 +142,9 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
         )
         self._pending_dock_status: str | None = None
         self.last_seen_segments: list[Any] | None = None
+        # Discovered saved maps {cloud_mapid: name}, learned from MapDescription
+        # frames on the biz/ stream and persisted; backs the Active Map selector.
+        self.last_seen_maps: dict[int, str] = {}
         self._store = Store(hass, 1, f"{DOMAIN}.{self.device_id}")
         self._map_data_chan_id: int | None = None
         self._map_data: MapData | None = None
@@ -430,6 +434,21 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
 
         channel_id, hex_data = result
         _LOGGER.debug("biz/ protocol-41 channel_id=%d, hex_len=%d", channel_id, len(hex_data))
+
+        # Map discovery: a small single-shot MapDescription frame carries the
+        # active map's id + friendly name (delivered on a map switch). Capture it
+        # for the Active Map selector, persist, and notify entities.
+        desc = try_extract_map_description(hex_data)
+        if desc is not None:
+            map_id, name = desc
+            if self.last_seen_maps.get(map_id) != name:
+                self.last_seen_maps[map_id] = name
+                _LOGGER.debug(
+                    "Discovered map %d = %r for %s", map_id, name, self.device_name
+                )
+                self.async_update_listeners()
+                self.hass.async_create_task(self.async_save_maps())
+            return
 
         # Small channels (<200 hex chars = ~100 bytes): try as robot pose (DynamicData).
         if len(hex_data) < 200:
@@ -842,6 +861,9 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
                 len(self.last_seen_segments) if self.last_seen_segments else 0,
                 self.device_name,
             )
+            self.last_seen_maps = {
+                int(k): v for k, v in (data.get("last_seen_maps") or {}).items()
+            }
             if map_b64 := data.get("map_image_png"):
                 self.map_image = base64.b64decode(map_b64)
                 _LOGGER.debug(
@@ -924,5 +946,16 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
         _LOGGER.debug(
             "Saved %s segments to storage for %s",
             len(segments_payload),
+            self.device_name,
+        )
+
+    async def async_save_maps(self) -> None:
+        """Persist discovered saved-map id→name to storage."""
+        data = await self._store.async_load() or {}
+        data["last_seen_maps"] = {str(k): v for k, v in self.last_seen_maps.items()}
+        await self._store.async_save(data)
+        _LOGGER.debug(
+            "Saved %s discovered maps to storage for %s",
+            len(self.last_seen_maps),
             self.device_name,
         )

--- a/custom_components/robovac_mqtt/select.py
+++ b/custom_components/robovac_mqtt/select.py
@@ -146,6 +146,7 @@ async def async_setup_entry(
         # than expose permanently-`unknown` UI.
         if coordinator.connection_type == "mqtt":
             candidates.append(SceneSelectEntity(coordinator))
+            candidates.append(ActiveMapSelectEntity(coordinator))
         # Room list is normally P2P-only too, but the user can supply a
         # manual {room_id: name} override through the options flow which
         # works on every transport.
@@ -444,6 +445,84 @@ class RoomSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
         await self.coordinator.async_send_command(command)
         self.coordinator.set_active_cleaning_targets(room_ids=[room_id])
 
+        self.async_write_ha_state()
+
+
+class ActiveMapSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
+    """Select entity for switching the active saved map.
+
+    Options are discovered from the cloud map stream: each saved map's id and
+    friendly name arrive as a ``MapDescription`` when the map becomes active
+    (novel/protobuf devices only). The list fills in as maps are seen — a
+    one-time cycle through the maps in the Eufy app, or normal use, populates it;
+    a map shows as ``Map (ID: <id>)`` until its name has been seen. Bulk
+    enumeration (``MAP_GET_ALL``) is delivered over P2P, which this integration
+    does not implement, so this is intentionally a learn-as-seen list.
+
+    Selecting an option sends ``map_load``. NOTE: the robot pose does not
+    re-localize onto the new map until the vacuum next MOVES — see the
+    ``map_load`` service docs for the single-room-clean workaround.
+    """
+
+    supported_api_types = (API_TYPE_NOVEL,)
+
+    def __init__(self, coordinator: EufyCleanCoordinator) -> None:
+        """Initialize the active-map select."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.device_id}_active_map"
+        self._attr_has_entity_name = True
+        self._attr_name = "Active Map"
+        self._attr_icon = "mdi:map-outline"
+        self._attr_device_info = coordinator.device_info
+
+    def _known_maps(self) -> dict[int, str]:
+        """Discovered ``{map_id: name}``, including the active map id if unnamed."""
+        maps = dict(self.coordinator.last_seen_maps or {})
+        active = self.coordinator.data.map_id
+        if active and active not in maps:
+            maps[active] = ""  # id-only; label falls back to "Map (ID: <id>)"
+        return maps
+
+    @property
+    def options(self) -> list[str]:
+        """Return discovered maps as labels, sorted by id for stable ordering."""
+        return [
+            _format_option_label({"id": mid, "name": name}, "Map")
+            for mid, name in sorted(self._known_maps().items())
+        ]
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the active map's label."""
+        active = self.coordinator.data.map_id
+        if not active:
+            return None
+        return _format_option_label(
+            {"id": active, "name": self._known_maps().get(active, "")}, "Map"
+        )
+
+    @property
+    def available(self) -> bool:
+        """Available once at least one map has been discovered."""
+        return super().available and bool(self._known_maps())
+
+    async def async_select_option(self, option: str) -> None:
+        """Switch the active map to the selected one via ``map_load``."""
+        target = next(
+            (
+                mid
+                for mid, name in self._known_maps().items()
+                if _format_option_label({"id": mid, "name": name}, "Map") == option
+            ),
+            None,
+        )
+        if target is None:
+            raise HomeAssistantError(f"Unknown map option: {option}")
+
+        command = self.coordinator.build_device_command("map_load", cloud_mapid=target)
+        if not command:
+            raise HomeAssistantError("map_load is not supported on this device")
+        await self.coordinator.async_send_command(command)
         self.async_write_ha_state()
 
 

--- a/custom_components/robovac_mqtt/select.py
+++ b/custom_components/robovac_mqtt/select.py
@@ -456,10 +456,10 @@ class MapSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
     arrives reliably over the DPS state stream (the same signal the Active Map
     sensor tracks), so every map the robot has been on is appended and becomes
     switchable, shown as ``Map (ID: <id>)``. A friendly name is layered in when
-    that map's ``MapDescription`` is seen on the biz stream. The list is persisted
-    so it survives restarts. Bulk enumeration (``MAP_GET_ALL``) is P2P-only, so
-    this is a learn-as-seen list — flip each map once (in the app or here) to seed
-    it, after which switching works from HA.
+    that map's ``MapDescription`` is seen on the biz stream — the device emits it
+    when you open multi-map management or rename a map in the app (a plain switch
+    carries only the id), after which the name is persisted with the id. Bulk
+    enumeration (``MAP_GET_ALL``) is P2P-only, so this is a learn-as-seen list.
 
     Selecting an option sends ``map_load``. NOTE: the robot pose does not
     re-localize onto the new map until the vacuum next MOVES — see the

--- a/custom_components/robovac_mqtt/select.py
+++ b/custom_components/robovac_mqtt/select.py
@@ -146,7 +146,7 @@ async def async_setup_entry(
         # than expose permanently-`unknown` UI.
         if coordinator.connection_type == "mqtt":
             candidates.append(SceneSelectEntity(coordinator))
-            candidates.append(ActiveMapSelectEntity(coordinator))
+            candidates.append(MapSelectEntity(coordinator))
         # Room list is normally P2P-only too, but the user can supply a
         # manual {room_id: name} override through the options flow which
         # works on every transport.
@@ -448,16 +448,18 @@ class RoomSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
         self.async_write_ha_state()
 
 
-class ActiveMapSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
-    """Select entity for switching the active saved map.
+class MapSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
+    """Writable map switcher ("Switch Map").
 
-    Options are discovered from the cloud map stream: each saved map's id and
-    friendly name arrive as a ``MapDescription`` when the map becomes active
-    (novel/protobuf devices only). The list fills in as maps are seen — a
-    one-time cycle through the maps in the Eufy app, or normal use, populates it;
-    a map shows as ``Map (ID: <id>)`` until its name has been seen. Bulk
-    enumeration (``MAP_GET_ALL``) is delivered over P2P, which this integration
-    does not implement, so this is intentionally a learn-as-seen list.
+    Distinct from the read-only "Active Map" *sensor*: this is the selector you
+    use to change maps. Options accumulate as the robot visits maps — the map id
+    arrives reliably over the DPS state stream (the same signal the Active Map
+    sensor tracks), so every map the robot has been on is appended and becomes
+    switchable, shown as ``Map (ID: <id>)``. A friendly name is layered in when
+    that map's ``MapDescription`` is seen on the biz stream. The list is persisted
+    so it survives restarts. Bulk enumeration (``MAP_GET_ALL``) is P2P-only, so
+    this is a learn-as-seen list — flip each map once (in the app or here) to seed
+    it, after which switching works from HA.
 
     Selecting an option sends ``map_load``. NOTE: the robot pose does not
     re-localize onto the new map until the vacuum next MOVES — see the
@@ -467,11 +469,11 @@ class ActiveMapSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntit
     supported_api_types = (API_TYPE_NOVEL,)
 
     def __init__(self, coordinator: EufyCleanCoordinator) -> None:
-        """Initialize the active-map select."""
+        """Initialize the map switcher select."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.device_id}_active_map"
+        self._attr_unique_id = f"{coordinator.device_id}_map_select"
         self._attr_has_entity_name = True
-        self._attr_name = "Active Map"
+        self._attr_name = "Switch Map"
         self._attr_icon = "mdi:map-outline"
         self._attr_device_info = coordinator.device_info
 

--- a/custom_components/robovac_mqtt/select.py
+++ b/custom_components/robovac_mqtt/select.py
@@ -456,10 +456,10 @@ class MapSelectEntity(CoordinatorEntity[EufyCleanCoordinator], SelectEntity):
     arrives reliably over the DPS state stream (the same signal the Active Map
     sensor tracks), so every map the robot has been on is appended and becomes
     switchable, shown as ``Map (ID: <id>)``. A friendly name is layered in when
-    that map's ``MapDescription`` is seen on the biz stream — the device emits it
-    when you open multi-map management or rename a map in the app (a plain switch
-    carries only the id), after which the name is persisted with the id. Bulk
-    enumeration (``MAP_GET_ALL``) is P2P-only, so this is a learn-as-seen list.
+    that map's ``MapDescription`` is seen on the biz stream — the device only
+    emits it when you rename the map in the app (a plain switch or view carries
+    only the id), after which the name is persisted with the id. Bulk enumeration
+    (``MAP_GET_ALL``) is P2P-only, so this is a learn-as-seen list.
 
     Selecting an option sends ``map_load``. NOTE: the robot pose does not
     re-localize onto the new map until the vacuum next MOVES — see the

--- a/custom_components/robovac_mqtt/services.yaml
+++ b/custom_components/robovac_mqtt/services.yaml
@@ -37,7 +37,9 @@ map_load:
   description: >-
     Switch the active map to another saved multi-map by its cloud map id (novel /
     protobuf devices only; scalar and legacy models have no multi-map). The map and
-    its room list switch over immediately.
+    its room list switch over immediately. For most uses the "Active Map" select
+    entity is easier — it lists your saved maps by name and calls this service for
+    you; this raw service is for scripts/automations that already know the id.
 
     NOTE: the robot pose does NOT switch automatically. After loading a map the
     robot's position / coordinate frame stays on the previous map until the vacuum
@@ -56,8 +58,10 @@ map_load:
     cloud_mapid:
       name: Cloud map id
       description: >-
-        The saved map's id, as reported by the device (the map_id seen in incoming
-        map data). Switch maps in the Eufy app once and note the id each map reports.
+        The saved map's id, as reported by the device. The easiest way to find it:
+        the "Active Map" select entity lists each discovered map as
+        "<name> (ID: <id>)" — cycle through your maps in the Eufy app once (with HA
+        running) so each map's id and name are learned, then read the ids there.
       required: true
       example: 7
       selector:

--- a/custom_components/robovac_mqtt/services.yaml
+++ b/custom_components/robovac_mqtt/services.yaml
@@ -37,9 +37,9 @@ map_load:
   description: >-
     Switch the active map to another saved multi-map by its cloud map id (novel /
     protobuf devices only; scalar and legacy models have no multi-map). The map and
-    its room list switch over immediately. For most uses the "Active Map" select
-    entity is easier — it lists your saved maps by name and calls this service for
-    you; this raw service is for scripts/automations that already know the id.
+    its room list switch over immediately. For most uses the "Switch Map" select
+    entity is easier — it lists the maps the robot has visited and calls this
+    service for you; this raw service is for scripts/automations that know the id.
 
     NOTE: the robot pose does NOT switch automatically. After loading a map the
     robot's position / coordinate frame stays on the previous map until the vacuum
@@ -59,9 +59,9 @@ map_load:
       name: Cloud map id
       description: >-
         The saved map's id, as reported by the device. The easiest way to find it:
-        the "Active Map" select entity lists each discovered map as
-        "<name> (ID: <id>)" — cycle through your maps in the Eufy app once (with HA
-        running) so each map's id and name are learned, then read the ids there.
+        the "Switch Map" select entity lists each visited map as "Map (ID: <id>)"
+        (with the friendly name once seen) — flip each map once in the Eufy app so
+        the robot reports it, then read the ids there.
       required: true
       example: 7
       selector:

--- a/custom_components/robovac_mqtt/services.yaml
+++ b/custom_components/robovac_mqtt/services.yaml
@@ -31,3 +31,46 @@ room_at_point:
           max: 1
           step: any
           mode: box
+
+map_load:
+  name: Load map
+  description: >-
+    Switch the active map to another saved multi-map by its cloud map id (novel /
+    protobuf devices only; scalar and legacy models have no multi-map). The map and
+    its room list switch over immediately.
+
+    NOTE: the robot pose does NOT switch automatically. After loading a map the
+    robot's position / coordinate frame stays on the previous map until the vacuum
+    RE-LOCALIZES, which only happens once it MOVES. To ground the new map right away,
+    follow this with a small movement — the most reliable is a single-room clean
+    (vacuum only, quiet, one pass), started from a script/automation or by picking a
+    room from the list in the Eufy Clean card. Avoid selecting the room by tapping it
+    on the map right after a switch: the coordinate frame hasn't re-grounded yet, so
+    map taps (and zone drawing) can resolve to the wrong spot. Once the robot moves
+    and re-localizes, the reported position snaps onto the loaded map.
+  target:
+    entity:
+      domain: vacuum
+      integration: robovac_mqtt
+  fields:
+    cloud_mapid:
+      name: Cloud map id
+      description: >-
+        The saved map's id, as reported by the device (the map_id seen in incoming
+        map data). Switch maps in the Eufy app once and note the id each map reports.
+      required: true
+      example: 7
+      selector:
+        number:
+          min: 1
+          mode: box
+    seq:
+      name: Sequence
+      description: Optional request sequence number the device echoes back in its acknowledgement. Leave as the default unless you need to correlate the ack.
+      required: false
+      default: 1
+      example: 1
+      selector:
+        number:
+          min: 0
+          mode: box

--- a/custom_components/robovac_mqtt/vacuum.py
+++ b/custom_components/robovac_mqtt/vacuum.py
@@ -17,6 +17,7 @@ from homeassistant.core import (
     SupportsResponse,
     callback,
 )
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -162,8 +163,8 @@ async def async_setup_entry(
     platform.async_register_entity_service(
         "map_load",
         {
-            vol.Required("cloud_mapid"): vol.Coerce(int),
-            vol.Optional("seq", default=1): vol.Coerce(int),
+            vol.Required("cloud_mapid"): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            vol.Optional("seq", default=1): vol.All(vol.Coerce(int), vol.Range(min=0)),
         },
         "async_map_load",
     )
@@ -479,17 +480,18 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
         (protobuf) feature; scalar/legacy devices have no multi-map.
         """
         if self.coordinator.api_type != "novel":
-            _LOGGER.warning(
-                "map_load ignored: switching maps is only supported on novel "
-                "(protobuf) devices, not api_type=%s",
-                self.coordinator.api_type,
+            raise HomeAssistantError(
+                "Switching maps is only supported on novel (protobuf) devices, "
+                f"not api_type={self.coordinator.api_type}"
             )
-            return
         command = self.coordinator.build_device_command(
             "map_load", cloud_mapid=int(cloud_mapid), seq=int(seq)
         )
         if not command:
-            return
+            raise HomeAssistantError(
+                "Failed to build map_load command "
+                "(unsupported device or invalid map id)"
+            )
         await self.coordinator.async_send_command(command)
 
     @property

--- a/custom_components/robovac_mqtt/vacuum.py
+++ b/custom_components/robovac_mqtt/vacuum.py
@@ -156,6 +156,17 @@ async def async_setup_entry(
         "async_room_at_point",
         supports_response=SupportsResponse.ONLY,
     )
+    # Switch the active map to another saved multi-map by its cloud map id
+    # (novel/protobuf devices only). See async_map_load / build_map_load_command
+    # for the pose-re-localization caveat.
+    platform.async_register_entity_service(
+        "map_load",
+        {
+            vol.Required("cloud_mapid"): vol.Coerce(int),
+            vol.Optional("seq", default=1): vol.Coerce(int),
+        },
+        "async_map_load",
+    )
 
 
 class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEntity):
@@ -456,6 +467,30 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
         """
         room_id, room_name = self.coordinator.room_id_at_normalized(x, y)
         return {"room_id": room_id, "room_name": room_name or ""}
+
+    async def async_map_load(self, cloud_mapid: int, seq: int = 1) -> None:
+        """Switch the active map to a saved multi-map by its cloud map id.
+
+        Loads the target map and its room list immediately. The robot re-localizes
+        onto the new map only when it next MOVES — see the ``map_load`` service
+        docs for the workaround: a single-room clean (via a script or the card's
+        room list) is the most reliable way to ground the pose; avoid map-tap or
+        zone targeting until the frame re-grounds. Multi-map switching is a novel
+        (protobuf) feature; scalar/legacy devices have no multi-map.
+        """
+        if self.coordinator.api_type != "novel":
+            _LOGGER.warning(
+                "map_load ignored: switching maps is only supported on novel "
+                "(protobuf) devices, not api_type=%s",
+                self.coordinator.api_type,
+            )
+            return
+        command = self.coordinator.build_device_command(
+            "map_load", cloud_mapid=int(cloud_mapid), seq=int(seq)
+        )
+        if not command:
+            return
+        await self.coordinator.async_send_command(command)
 
     @property
     def supported_features(self) -> VacuumEntityFeature:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5,6 +5,7 @@ import base64
 from custom_components.robovac_mqtt.api.commands import (
     _build_off_peak_sub_bytes,
     build_command,
+    build_map_load_command,
     build_set_boost_iq_command,
     build_set_child_lock_command,
     build_set_cleaning_intensity_command,
@@ -24,6 +25,9 @@ from custom_components.robovac_mqtt.const import (
     SCALAR_DPS,
 )
 from custom_components.robovac_mqtt.proto.cloud.control_pb2 import ModeCtrlRequest
+from custom_components.robovac_mqtt.proto.cloud.multi_maps_pb2 import (
+    MultiMapsManageRequest,
+)
 from custom_components.robovac_mqtt.proto.cloud.unisetting_pb2 import UnisettingRequest
 from custom_components.robovac_mqtt.utils import decode, decode_varint, encode_varint
 
@@ -118,6 +122,34 @@ def test_build_command_zone_clean_dispatch():
     decoded = decode(ModeCtrlRequest, result[DPS_MAP["PLAY_PAUSE"]])
     assert decoded.method == EUFY_CLEAN_CONTROL.START_SELECT_ZONES_CLEAN
     assert decoded.select_zones_clean.map_id == 1
+
+
+def test_build_map_load_command():
+    """Map load encodes a MAP_LOAD MultiMapsManageRequest on DPS 172."""
+    result = build_map_load_command(7, seq=5)
+
+    assert DPS_MAP["MULTI_MAP_MANAGE"] in result
+    decoded = decode(MultiMapsManageRequest, result[DPS_MAP["MULTI_MAP_MANAGE"]])
+    assert decoded.method == MultiMapsManageRequest.MAP_LOAD
+    assert decoded.seq == 5
+    assert decoded.common.cloud_mapid == 7
+
+
+def test_build_map_load_command_invalid_id():
+    """A non-positive cloud_mapid dispatches nothing."""
+    assert not build_map_load_command(0)
+    assert not build_map_load_command(-1)
+
+
+def test_build_command_map_load_dispatch():
+    """build_command routes 'map_load' to the map-load builder."""
+    result = build_command("map_load", cloud_mapid=6, seq=2)
+
+    assert DPS_MAP["MULTI_MAP_MANAGE"] in result
+    decoded = decode(MultiMapsManageRequest, result[DPS_MAP["MULTI_MAP_MANAGE"]])
+    assert decoded.method == MultiMapsManageRequest.MAP_LOAD
+    assert decoded.common.cloud_mapid == 6
+    assert decoded.seq == 2
 
 
 # ── G-series scalar command builders (T2210/G50) ─────────────────────

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -200,6 +200,81 @@ def test_handle_mqtt_message(mock_hass, mock_login):
         coordinator.async_set_updated_data.assert_called_with(new_state)
 
 
+def test_remember_map_id_seeds_and_dedupes(mock_hass, mock_login):
+    """A visited map id is recorded once and persisted; re-seeing it or a
+    non-positive/missing id is a no-op (cheap to call on every state)."""
+    device_info = {
+        "deviceId": "test_id",
+        "deviceModel": "T2118",
+        "deviceName": "Test Vac",
+    }
+    coordinator = EufyCleanCoordinator(mock_hass, mock_login, device_info)
+    coordinator.async_save_maps = MagicMock()
+
+    coordinator._remember_map_id(4)
+    assert coordinator.last_seen_maps == {4: ""}
+    assert coordinator.async_save_maps.call_count == 1
+
+    # Already known -> no re-write, no extra save.
+    coordinator._remember_map_id(4)
+    assert coordinator.last_seen_maps == {4: ""}
+    assert coordinator.async_save_maps.call_count == 1
+
+    # Non-positive / missing ids are ignored.
+    coordinator._remember_map_id(0)
+    coordinator._remember_map_id(None)
+    assert coordinator.last_seen_maps == {4: ""}
+    assert coordinator.async_save_maps.call_count == 1
+
+
+def test_handle_mqtt_message_seeds_startup_map(mock_hass, mock_login):
+    """The map active at STARTUP is persisted even though it never arrives as a
+    map_id 'change' — regression for the selector dropping it after a switch."""
+    device_info = {
+        "deviceId": "test_id",
+        "deviceModel": "T2118",
+        "deviceName": "Test Vac",
+    }
+    coordinator = EufyCleanCoordinator(mock_hass, mock_login, device_info)
+    coordinator.async_set_updated_data = MagicMock()
+    coordinator.async_save_maps = MagicMock()
+
+    payload_bytes = b'{"payload": {"data": {"101": "val"}}}'
+    with patch(
+        "custom_components.robovac_mqtt.coordinator.update_state"
+    ) as mock_update:
+        # changes == {} -> the startup map_id is NOT flagged as changed.
+        mock_update.return_value = (VacuumState(map_id=4), {})
+        coordinator._handle_mqtt_message(payload_bytes)
+
+    assert coordinator.last_seen_maps == {4: ""}
+    coordinator.async_save_maps.assert_called_once()
+
+
+def test_handle_mqtt_message_switch_keeps_prior_map(mock_hass, mock_login):
+    """Start on map 4, then switch to 6 in the app: both stay in the selector.
+    (The reported bug was 4 disappearing until it was switched back to.)"""
+    device_info = {
+        "deviceId": "test_id",
+        "deviceModel": "T2118",
+        "deviceName": "Test Vac",
+    }
+    coordinator = EufyCleanCoordinator(mock_hass, mock_login, device_info)
+    coordinator.async_set_updated_data = MagicMock()
+    coordinator.async_save_maps = MagicMock()
+
+    payload_bytes = b'{"payload": {"data": {"101": "val"}}}'
+    with patch(
+        "custom_components.robovac_mqtt.coordinator.update_state"
+    ) as mock_update:
+        mock_update.return_value = (VacuumState(map_id=4), {})  # startup on 4
+        coordinator._handle_mqtt_message(payload_bytes)
+        mock_update.return_value = (VacuumState(map_id=6), {"map_id": 6})  # switch
+        coordinator._handle_mqtt_message(payload_bytes)
+
+    assert coordinator.last_seen_maps == {4: "", 6: ""}
+
+
 @pytest.mark.asyncio
 async def test_async_send_command(mock_hass, mock_login):
     """Test sending commands."""

--- a/tests/test_map_stream.py
+++ b/tests/test_map_stream.py
@@ -9,6 +9,7 @@ from custom_components.robovac_mqtt.api.map_stream import (
     parse_biz_protocol41,
     render_map_png,
     try_extract_map_data,
+    try_extract_map_description,
 )
 from custom_components.robovac_mqtt.proto.cloud import stream_pb2
 from custom_components.robovac_mqtt.utils import encode_varint
@@ -177,3 +178,42 @@ def test_render_map_png_rejects_oversized():
     map_data = MapData(raw_pixels=b"", width=5000, height=5000)
     with pytest.raises(ValueError, match="exceed safety limit"):
         render_map_png(map_data)
+
+
+# ---------------------------------------------------------------------------
+# try_extract_map_description — map id + name discovery
+# ---------------------------------------------------------------------------
+
+
+def _make_map_desc_hex(map_id: int, name: str) -> str:
+    """Return hex of a varint-prefixed MapDescription proto."""
+    body = stream_pb2.MapDescription(map_id=map_id, name=name).SerializeToString()
+    return (encode_varint(len(body)) + body).hex()
+
+
+def test_map_description_extracts_id_and_name():
+    """A well-formed MapDescription yields (map_id, name)."""
+    assert try_extract_map_description(_make_map_desc_hex(6, "My home")) == (
+        6,
+        "My home",
+    )
+
+
+def test_map_description_rejects_zero_id():
+    """map_id 0 is not a real saved map -> None (drops the RoomParams misparse)."""
+    assert try_extract_map_description(_make_map_desc_hex(0, "My home")) is None
+
+
+def test_map_description_rejects_empty_name():
+    """An empty name is not usable as a label -> None."""
+    assert try_extract_map_description(_make_map_desc_hex(7, "")) is None
+
+
+def test_map_description_rejects_non_printable_name():
+    """A non-printable name signals a misparsed frame -> None."""
+    assert try_extract_map_description(_make_map_desc_hex(7, "bad\x00name")) is None
+
+
+def test_map_description_rejects_garbage():
+    """Non-hex / undecodable input -> None, never raises."""
+    assert try_extract_map_description("zznothex") is None

--- a/tests/test_map_stream.py
+++ b/tests/test_map_stream.py
@@ -217,3 +217,11 @@ def test_map_description_rejects_non_printable_name():
 def test_map_description_rejects_garbage():
     """Non-hex / undecodable input -> None, never raises."""
     assert try_extract_map_description("zznothex") is None
+
+
+def test_map_description_strips_whitespace():
+    """A name seeded with a trailing space (Eufy same-name workaround) is trimmed."""
+    assert try_extract_map_description(_make_map_desc_hex(6, "The main floor ")) == (
+        6,
+        "The main floor",
+    )

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -11,10 +11,10 @@ from homeassistant.exceptions import HomeAssistantError
 from custom_components.robovac_mqtt.coordinator import EufyCleanCoordinator
 from custom_components.robovac_mqtt.models import VacuumState
 from custom_components.robovac_mqtt.select import (
-    ActiveMapSelectEntity,
     CleaningIntensitySelectEntity,
     CleaningModeSelectEntity,
     DockSelectEntity,
+    MapSelectEntity,
     MopIntensitySelectEntity,
     RoomSelectEntity,
     SceneSelectEntity,
@@ -397,17 +397,17 @@ async def test_legacy_coordinator_excludes_novel_only_selects():
 
 
 # ---------------------------------------------------------------------------
-# ActiveMapSelectEntity — map switching + learn-as-seen discovery
+# MapSelectEntity — map switching + learn-as-seen discovery
 # ---------------------------------------------------------------------------
 
 
 def _active_map_entity(mock_coordinator, maps, active_id):
-    """Build an ActiveMapSelectEntity with discovered maps + an active map id."""
+    """Build a MapSelectEntity with discovered maps + an active map id."""
     mock_coordinator.last_seen_maps = maps
     data = VacuumState()
     data.map_id = active_id
     mock_coordinator.data = data
-    return ActiveMapSelectEntity(mock_coordinator)
+    return MapSelectEntity(mock_coordinator)
 
 
 def test_active_map_options_and_current(mock_coordinator):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -6,10 +6,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.const import EntityCategory
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.robovac_mqtt.coordinator import EufyCleanCoordinator
 from custom_components.robovac_mqtt.models import VacuumState
 from custom_components.robovac_mqtt.select import (
+    ActiveMapSelectEntity,
     CleaningIntensitySelectEntity,
     CleaningModeSelectEntity,
     DockSelectEntity,
@@ -392,3 +394,62 @@ async def test_legacy_coordinator_excludes_novel_only_selects():
         assert novel_only not in classes, f"{novel_only} should be hidden on legacy"
     # The universal suction-level select stays (set_fan_speed works on legacy).
     assert "SuctionLevelSelectEntity" in classes
+
+
+# ---------------------------------------------------------------------------
+# ActiveMapSelectEntity — map switching + learn-as-seen discovery
+# ---------------------------------------------------------------------------
+
+
+def _active_map_entity(mock_coordinator, maps, active_id):
+    """Build an ActiveMapSelectEntity with discovered maps + an active map id."""
+    mock_coordinator.last_seen_maps = maps
+    data = VacuumState()
+    data.map_id = active_id
+    mock_coordinator.data = data
+    return ActiveMapSelectEntity(mock_coordinator)
+
+
+def test_active_map_options_and_current(mock_coordinator):
+    """Discovered maps become '<name> (ID: <id>)' options; current tracks map_id."""
+    entity = _active_map_entity(mock_coordinator, {6: "My home", 7: "Testing map"}, 6)
+    assert entity.options == ["My home (ID: 6)", "Testing map (ID: 7)"]
+    assert entity.current_option == "My home (ID: 6)"
+
+
+def test_active_map_unnamed_active_falls_back(mock_coordinator):
+    """The active map, seen by id only, shows as 'Map (ID: <id>)'."""
+    entity = _active_map_entity(mock_coordinator, {}, 6)
+    assert entity.options == ["Map (ID: 6)"]
+    assert entity.current_option == "Map (ID: 6)"
+
+
+def test_active_map_empty_when_nothing_known(mock_coordinator):
+    """No discovered maps and no active id -> no options, no current."""
+    entity = _active_map_entity(mock_coordinator, {}, 0)
+    assert entity.options == []
+    assert entity.current_option is None
+
+
+@pytest.mark.asyncio
+async def test_active_map_select_sends_map_load(mock_coordinator):
+    """Selecting a map resolves its id and sends map_load."""
+    entity = _active_map_entity(mock_coordinator, {6: "My home"}, 7)
+    mock_coordinator.build_device_command = MagicMock(return_value={"172": "x"})
+    entity.async_write_ha_state = MagicMock()
+
+    await entity.async_select_option("My home (ID: 6)")
+
+    mock_coordinator.build_device_command.assert_called_once_with(
+        "map_load", cloud_mapid=6
+    )
+    mock_coordinator.async_send_command.assert_awaited_once_with({"172": "x"})
+
+
+@pytest.mark.asyncio
+async def test_active_map_select_unknown_raises(mock_coordinator):
+    """Selecting an option that maps to no known id raises."""
+    entity = _active_map_entity(mock_coordinator, {6: "My home"}, 6)
+    entity.async_write_ha_state = MagicMock()
+    with pytest.raises(HomeAssistantError):
+        await entity.async_select_option("Nope (ID: 99)")

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.components.vacuum import VacuumActivity
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.robovac_mqtt.const import (
     EUFY_CLEAN_CLEAN_SPEED,
@@ -339,4 +340,42 @@ async def test_async_clean_segments_empty_list(mock_coordinator, mock_config_ent
     entity.hass = mock_coordinator.hass
 
     await entity.async_clean_segments([])
+    mock_coordinator.async_send_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_map_load_novel_sends_command(mock_coordinator, mock_config_entry):
+    """map_load on a novel device builds and sends the command."""
+    mock_coordinator.api_type = "novel"
+    mock_coordinator.build_device_command = MagicMock(return_value={"172": "x"})
+    entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
+
+    await entity.async_map_load(6, seq=2)
+
+    mock_coordinator.build_device_command.assert_called_once_with(
+        "map_load", cloud_mapid=6, seq=2
+    )
+    mock_coordinator.async_send_command.assert_awaited_once_with({"172": "x"})
+
+
+@pytest.mark.asyncio
+async def test_map_load_scalar_raises(mock_coordinator, mock_config_entry):
+    """map_load on a scalar/legacy device raises instead of silently no-oping."""
+    mock_coordinator.api_type = "scalar"
+    entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_map_load(6)
+    mock_coordinator.async_send_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_map_load_empty_command_raises(mock_coordinator, mock_config_entry):
+    """An empty builder result (unsupported / invalid id) raises."""
+    mock_coordinator.api_type = "novel"
+    mock_coordinator.build_device_command = MagicMock(return_value={})
+    entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_map_load(6)
     mock_coordinator.async_send_command.assert_not_called()


### PR DESCRIPTION
## Add a `map_load` service to switch the active map

Adds a `robovac_mqtt.map_load` entity service that switches the vacuum's **active
multi-map** by its cloud map id — the "which floor/map is loaded" operation that
currently can only be done from the Eufy app.

### Mechanism

Sends `MultiMapsManageRequest{ method: MAP_LOAD, common.cloud_mapid }` through the
existing `encode_message` path onto the multi-map-manage DP (**172**,
`DPS_MAP["MULTI_MAP_MANAGE"]`) — the same DP the integration already *decodes* for
`MultiMapsManageResponse`. The implementation mirrors `build_room_clean_command` /
`build_zone_clean_command`.

Verified working on-device (Eufy X10, novel/protobuf): calling the service switches
the active map, and the incoming `MAP_DATA` then reports the loaded map's id + its
room list.

### What's included

- `build_map_load_command()` in `api/commands.py`, wired into the `build_command`
  dispatcher (`map_load`).
- `async_map_load` handler + entity-service registration in `vacuum.py`. Guarded to
  **novel (protobuf) devices** — scalar/legacy models have no multi-map.
- `services.yaml` documentation (including the caveat below).
- Unit tests: builder encode roundtrip, dispatcher routing, and the non-positive-id
  guard.

### Known caveat (documented in the service description)

Loading a map switches the **active map + room list immediately**, but the robot's
**pose / coordinate frame stays on the previous map until it next moves** — it
re-localizes only on movement (this firmware has no "re-map without cleaning"). The
service description notes the workaround: follow the switch with a **single-room
clean** (vacuum only, quiet, one pass), started from a script or by picking a room
from the **list** in the Eufy Clean card. Avoid map-tap room selection and zone
drawing until the frame re-grounds — those are coordinate-based, and the transform
is stale right after a switch. Once the robot moves, the position snaps onto the
loaded map.

### Notes

- No manifest version bump (left to maintainer release chores).
- `flake8` + `isort --profile black` clean on the changed files.

### Usage

```yaml
service: robovac_mqtt.map_load
target:
  entity_id: vacuum.your_robovac
data:
  cloud_mapid: 7
```
