### PR TITLE
Expose cleaning scenes as segments when native room support is unavailable

### DIFF
--- a/custom_components/robovac_mqtt/vacuum.py
+++ b/custom_components/robovac_mqtt/vacuum.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
-from homeassistant.exceptions import HomeAssistantError
 import voluptuous as vol
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.components.vacuum import (
     StateVacuumEntity,
     VacuumActivity,

--- a/custom_components/robovac_mqtt/vacuum.py
+++ b/custom_components/robovac_mqtt/vacuum.py
@@ -458,18 +458,23 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
         if not scene_ids:
             return
 
+        if len(scene_ids) > 1:
+            _LOGGER.warning(
+                "Multiple scene-based segments selected; only the first scene will be cleaned"
+            )
+
         scene_lookup = {
             scene["id"]: scene.get("name")
             for scene in self.coordinator.data.scenes
             if "id" in scene
         }
 
-        for scene_id in scene_ids:
-            scene_name = scene_lookup.get(scene_id)
-            await self.coordinator.async_send_command(
-                build_command("scene_clean", scene_id=scene_id)
-            )
-            self.coordinator.set_active_scene(scene_id, scene_name)
+        scene_id = scene_ids[0]
+        scene_name = scene_lookup.get(scene_id)
+        await self.coordinator.async_send_command(
+            build_command("scene_clean", scene_id=scene_id)
+        )
+        self.coordinator.set_active_scene(scene_id, scene_name)
 
 
     async def async_clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:

--- a/custom_components/robovac_mqtt/vacuum.py
+++ b/custom_components/robovac_mqtt/vacuum.py
@@ -471,10 +471,10 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
 
         scene_id = scene_ids[0]
         scene_name = scene_lookup.get(scene_id)
-        await self.coordinator.async_send_command(
-            build_command("scene_clean", scene_id=scene_id)
-        )
-        self.coordinator.set_active_scene(scene_id, scene_name)
+        command = self.coordinator.build_device_command("scene_clean", scene_id=scene_id)
+        if command:
+            await self.coordinator.async_send_command(command)
+            self.coordinator.set_active_scene(scene_id, scene_name)
 
 
     async def async_clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:

--- a/custom_components/robovac_mqtt/vacuum.py
+++ b/custom_components/robovac_mqtt/vacuum.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
-
+from homeassistant.exceptions import HomeAssistantError
 import voluptuous as vol
 from homeassistant.components.vacuum import (
     StateVacuumEntity,
@@ -459,8 +459,8 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
             return
 
         if len(scene_ids) > 1:
-            _LOGGER.warning(
-                "Multiple scene-based segments selected; only the first scene will be cleaned"
+            raise HomeAssistantError(
+                "Multiple scene-based segments selected; device supports cleaning only a single scene-based segment"
             )
 
         scene_lookup = {

--- a/custom_components/robovac_mqtt/vacuum.py
+++ b/custom_components/robovac_mqtt/vacuum.py
@@ -212,17 +212,36 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
                 )
 
     def _get_room_segments(self) -> list[Segment]:
-        """Return segments derived from the latest mapped rooms."""
+        """Return segments derived from the latest mapped rooms or scenes.
+
+        Some devices do not expose native room/segment data but do support
+        named cleaning scenes. Those scenes can be treated as segments for Home
+        Assistant room mapping and segment cleaning.
+        """
         rooms = self.coordinator.data.rooms or []
+        if rooms:
+            return [
+                Segment(
+                    id=str(room["id"]), name=room.get("name") or f"Room {room['id']}"
+                )
+                for room in rooms
+                if "id" in room
+            ]
+
+        scenes = self.coordinator.data.scenes or []
         return [
-            Segment(id=str(room["id"]), name=room.get("name") or f"Room {room['id']}")
-            for room in rooms
-            if "id" in room
+            Segment(
+                id=str(scene["id"]), name=scene.get("name") or f"Scene {scene['id']}"
+            )
+            for scene in scenes
+            if "id" in scene
         ]
 
     def _get_extra_room_attributes(self) -> list[dict[str, str]]:
         """Return room attributes derived from current segments."""
-        return _rooms_to_attributes(self.coordinator.data.rooms)
+        return _rooms_to_attributes(
+            self.coordinator.data.rooms or self.coordinator.data.scenes
+        )
 
     def _get_extra_segment_attributes(self) -> list[dict[str, Any]]:
         """Return segment attributes derived from current segments."""
@@ -434,6 +453,25 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
         self.coordinator.set_active_cleaning_targets(zone_count=len(quads_cm))
         await self.coordinator.async_send_command(command)
 
+    async def _async_handle_scene_clean(self, scene_ids: list[int]) -> None:
+        """Handle cleaning scenes when no native rooms are available."""
+        if not scene_ids:
+            return
+
+        scene_lookup = {
+            scene["id"]: scene.get("name")
+            for scene in self.coordinator.data.scenes
+            if "id" in scene
+        }
+
+        for scene_id in scene_ids:
+            scene_name = scene_lookup.get(scene_id)
+            await self.coordinator.async_send_command(
+                build_command("scene_clean", scene_id=scene_id)
+            )
+            self.coordinator.set_active_scene(scene_id, scene_name)
+
+
     async def async_clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:
         """Clean specific segments with current custom parameters."""
         room_ids = [
@@ -441,6 +479,10 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
         ]
 
         if not room_ids:
+            return
+
+        if not self.coordinator.data.rooms and self.coordinator.data.scenes:
+            await self._async_handle_scene_clean(room_ids)
             return
 
         # Use the same room_clean handling logic that supports custom parameters
@@ -626,6 +668,9 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
                 except (ValueError, TypeError):
                     pass
             if room_ids:
+                if not self.coordinator.data.rooms and self.coordinator.data.scenes:
+                    await self._async_handle_scene_clean(room_ids)
+                    return
                 await self._async_handle_room_clean({"room_ids": room_ids})
                 return
             return

--- a/custom_components/robovac_mqtt/vacuum.py
+++ b/custom_components/robovac_mqtt/vacuum.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+
 import voluptuous as vol
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.components.vacuum import (
     StateVacuumEntity,
     VacuumActivity,
@@ -17,6 +17,7 @@ from homeassistant.core import (
     SupportsResponse,
     callback,
 )
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -475,7 +476,6 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
         if command:
             await self.coordinator.async_send_command(command)
             self.coordinator.set_active_scene(scene_id, scene_name)
-
 
     async def async_clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:
         """Clean specific segments with current custom parameters."""

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -333,6 +333,64 @@ async def test_app_segment_clean_invalid_ids(mock_coordinator, mock_config_entry
 
 
 @pytest.mark.asyncio
+async def test_app_segment_clean_uses_scene_clean_when_no_rooms(
+    mock_coordinator, mock_config_entry
+):
+    """Test app_segment_clean routes to scene_clean when there are no rooms."""
+    mock_coordinator.data.rooms = []
+    mock_coordinator.data.scenes = [{"id": 1, "name": "Kitchen Scene"}]
+    mock_coordinator.set_active_scene = MagicMock()
+    entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
+    entity.hass = mock_coordinator.hass
+
+    with patch("custom_components.robovac_mqtt.vacuum.build_command") as mock_build:
+        mock_build.return_value = {"cmd": "scene"}
+        await entity.async_send_command("app_segment_clean", params=["1"])
+
+        mock_build.assert_called_with("scene_clean", scene_id=1)
+        mock_coordinator.async_send_command.assert_called_with({"cmd": "scene"})
+        mock_coordinator.set_active_scene.assert_called_with(1, "Kitchen Scene")
+
+
+@pytest.mark.asyncio
+async def test_async_clean_segments_uses_scene_clean_when_no_rooms(
+    mock_coordinator, mock_config_entry
+):
+    """Test async_clean_segments uses scene_clean when no rooms are available."""
+    mock_coordinator.data.rooms = []
+    mock_coordinator.data.scenes = [{"id": 2, "name": "Living Room Scene"}]
+    mock_coordinator.set_active_scene = MagicMock()
+    mock_coordinator.async_send_command = AsyncMock()
+
+    entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
+    with patch("custom_components.robovac_mqtt.vacuum.build_command") as mock_build:
+        mock_build.return_value = {"cmd": "scene"}
+        await entity.async_clean_segments(["2"])
+
+        mock_build.assert_called_with("scene_clean", scene_id=2)
+        mock_coordinator.async_send_command.assert_called_once_with({"cmd": "scene"})
+        mock_coordinator.set_active_scene.assert_called_with(2, "Living Room Scene")
+
+
+def test_get_segments_falls_back_to_scenes(mock_coordinator, mock_config_entry):
+    """Test that async_get_segments falls back to scenes when no rooms exist."""
+    mock_coordinator.data.rooms = []
+    mock_coordinator.data.scenes = [
+        {"id": 1, "name": "Kitchen Scene"},
+        {"id": 2, "name": "Bedroom Scene"},
+    ]
+
+    entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
+    segments = entity._get_room_segments()
+
+    assert len(segments) == 2
+    assert segments[0].id == "1"
+    assert segments[0].name == "Kitchen Scene"
+    assert segments[1].id == "2"
+    assert segments[1].name == "Bedroom Scene"
+
+
+@pytest.mark.asyncio
 async def test_async_clean_segments_empty_list(mock_coordinator, mock_config_entry):
     """Test async_clean_segments with empty list does nothing."""
     entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -353,6 +353,29 @@ async def test_app_segment_clean_uses_scene_clean_when_no_rooms(
 
 
 @pytest.mark.asyncio
+async def test_app_segment_clean_uses_first_scene_when_multiple_selected(
+    mock_coordinator, mock_config_entry
+):
+    """Test app_segment_clean uses only the first scene when multiple are selected."""
+    mock_coordinator.data.rooms = []
+    mock_coordinator.data.scenes = [
+        {"id": 1, "name": "Kitchen Scene"},
+        {"id": 2, "name": "Bedroom Scene"},
+    ]
+    mock_coordinator.set_active_scene = MagicMock()
+    entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
+    entity.hass = mock_coordinator.hass
+
+    with patch("custom_components.robovac_mqtt.vacuum.build_command") as mock_build:
+        mock_build.return_value = {"cmd": "scene"}
+        await entity.async_send_command("app_segment_clean", params=["1", "2"])
+
+        mock_build.assert_called_once_with("scene_clean", scene_id=1)
+        mock_coordinator.async_send_command.assert_called_once_with({"cmd": "scene"})
+        mock_coordinator.set_active_scene.assert_called_with(1, "Kitchen Scene")
+
+
+@pytest.mark.asyncio
 async def test_async_clean_segments_uses_scene_clean_when_no_rooms(
     mock_coordinator, mock_config_entry
 ):
@@ -370,6 +393,29 @@ async def test_async_clean_segments_uses_scene_clean_when_no_rooms(
         mock_build.assert_called_with("scene_clean", scene_id=2)
         mock_coordinator.async_send_command.assert_called_once_with({"cmd": "scene"})
         mock_coordinator.set_active_scene.assert_called_with(2, "Living Room Scene")
+
+
+@pytest.mark.asyncio
+async def test_async_clean_segments_uses_first_scene_when_multiple_selected(
+    mock_coordinator, mock_config_entry
+):
+    """Test async_clean_segments uses only the first scene when multiple are selected."""
+    mock_coordinator.data.rooms = []
+    mock_coordinator.data.scenes = [
+        {"id": 1, "name": "Kitchen Scene"},
+        {"id": 2, "name": "Bedroom Scene"},
+    ]
+    mock_coordinator.set_active_scene = MagicMock()
+    mock_coordinator.async_send_command = AsyncMock()
+
+    entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
+    with patch("custom_components.robovac_mqtt.vacuum.build_command") as mock_build:
+        mock_build.return_value = {"cmd": "scene"}
+        await entity.async_clean_segments(["1", "2"])
+
+        mock_build.assert_called_once_with("scene_clean", scene_id=1)
+        mock_coordinator.async_send_command.assert_called_once_with({"cmd": "scene"})
+        mock_coordinator.set_active_scene.assert_called_with(1, "Kitchen Scene")
 
 
 def test_get_segments_falls_back_to_scenes(mock_coordinator, mock_config_entry):

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -364,6 +364,7 @@ async def test_app_segment_clean_raises_on_multiple_scenes(
     with pytest.raises(HomeAssistantError):
         await entity.async_send_command("app_segment_clean", params=["1", "2"])
 
+
 @pytest.mark.asyncio
 async def test_async_clean_segments_uses_scene_clean_when_no_rooms(
     mock_coordinator, mock_config_entry
@@ -381,6 +382,7 @@ async def test_async_clean_segments_uses_scene_clean_when_no_rooms(
     mock_coordinator.async_send_command.assert_called_once_with({"cmd": "val"})
     mock_coordinator.set_active_scene.assert_called_with(2, "Living Room Scene")
 
+
 @pytest.mark.asyncio
 async def test_async_clean_segments_raises_on_multiple_scenes(
     mock_coordinator, mock_config_entry
@@ -397,7 +399,6 @@ async def test_async_clean_segments_raises_on_multiple_scenes(
     entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
     with pytest.raises(HomeAssistantError):
         await entity.async_clean_segments(["1", "2"])
-
 
 
 def test_get_segments_falls_back_to_scenes(mock_coordinator, mock_config_entry):

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -343,20 +343,15 @@ async def test_app_segment_clean_uses_scene_clean_when_no_rooms(
     entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
     entity.hass = mock_coordinator.hass
 
-    with patch("custom_components.robovac_mqtt.vacuum.build_command") as mock_build:
-        mock_build.return_value = {"cmd": "scene"}
-        await entity.async_send_command("app_segment_clean", params=["1"])
-
-        mock_build.assert_called_with("scene_clean", scene_id=1)
-        mock_coordinator.async_send_command.assert_called_with({"cmd": "scene"})
-        mock_coordinator.set_active_scene.assert_called_with(1, "Kitchen Scene")
+    await entity.async_send_command("app_segment_clean", params=["1"])
+    mock_coordinator.build_device_command.assert_called_with("scene_clean", scene_id=1)
 
 
 @pytest.mark.asyncio
-async def test_app_segment_clean_uses_first_scene_when_multiple_selected(
+async def test_app_segment_clean_raises_on_multiple_scenes(
     mock_coordinator, mock_config_entry
 ):
-    """Test app_segment_clean uses only the first scene when multiple are selected."""
+    """Test app_segment_clean raises when multiple scenes are selected."""
     mock_coordinator.data.rooms = []
     mock_coordinator.data.scenes = [
         {"id": 1, "name": "Kitchen Scene"},
@@ -366,14 +361,8 @@ async def test_app_segment_clean_uses_first_scene_when_multiple_selected(
     entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
     entity.hass = mock_coordinator.hass
 
-    with patch("custom_components.robovac_mqtt.vacuum.build_command") as mock_build:
-        mock_build.return_value = {"cmd": "scene"}
+    with pytest.raises(HomeAssistantError):
         await entity.async_send_command("app_segment_clean", params=["1", "2"])
-
-        mock_build.assert_called_once_with("scene_clean", scene_id=1)
-        mock_coordinator.async_send_command.assert_called_once_with({"cmd": "scene"})
-        mock_coordinator.set_active_scene.assert_called_with(1, "Kitchen Scene")
-
 
 @pytest.mark.asyncio
 async def test_async_clean_segments_uses_scene_clean_when_no_rooms(
@@ -386,20 +375,17 @@ async def test_async_clean_segments_uses_scene_clean_when_no_rooms(
     mock_coordinator.async_send_command = AsyncMock()
 
     entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
-    with patch("custom_components.robovac_mqtt.vacuum.build_command") as mock_build:
-        mock_build.return_value = {"cmd": "scene"}
-        await entity.async_clean_segments(["2"])
+    await entity.async_clean_segments(["2"])
 
-        mock_build.assert_called_with("scene_clean", scene_id=2)
-        mock_coordinator.async_send_command.assert_called_once_with({"cmd": "scene"})
-        mock_coordinator.set_active_scene.assert_called_with(2, "Living Room Scene")
-
+    mock_coordinator.build_device_command.assert_called_with("scene_clean", scene_id=2)
+    mock_coordinator.async_send_command.assert_called_once_with({"cmd": "val"})
+    mock_coordinator.set_active_scene.assert_called_with(2, "Living Room Scene")
 
 @pytest.mark.asyncio
-async def test_async_clean_segments_uses_first_scene_when_multiple_selected(
+async def test_async_clean_segments_raises_on_multiple_scenes(
     mock_coordinator, mock_config_entry
 ):
-    """Test async_clean_segments uses only the first scene when multiple are selected."""
+    """Test app_segment_clean raises when multiple scenes are selected."""
     mock_coordinator.data.rooms = []
     mock_coordinator.data.scenes = [
         {"id": 1, "name": "Kitchen Scene"},
@@ -409,13 +395,9 @@ async def test_async_clean_segments_uses_first_scene_when_multiple_selected(
     mock_coordinator.async_send_command = AsyncMock()
 
     entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
-    with patch("custom_components.robovac_mqtt.vacuum.build_command") as mock_build:
-        mock_build.return_value = {"cmd": "scene"}
+    with pytest.raises(HomeAssistantError):
         await entity.async_clean_segments(["1", "2"])
 
-        mock_build.assert_called_once_with("scene_clean", scene_id=1)
-        mock_coordinator.async_send_command.assert_called_once_with({"cmd": "scene"})
-        mock_coordinator.set_active_scene.assert_called_with(1, "Kitchen Scene")
 
 
 def test_get_segments_falls_back_to_scenes(mock_coordinator, mock_config_entry):

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.components.vacuum import VacuumActivity
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.robovac_mqtt.const import (
     EUFY_CLEAN_CLEAN_SPEED,


### PR DESCRIPTION
**Summary**

This PR adds a fallback that exposes cleaning _scenes_ as _Home Assistant segments_ for devices that do not provide native room/segment information.

When native rooms are available, the existing behavior is unchanged. If no rooms are exposed but the device provides cleaning scenes, those scenes are exposed as segments instead. **This enables Home Assistant’s native room mapping and segment cleaning UI on models such as the Eufy Omni C20.**

**Changes**

* Fall back to scenes when no native room/segment data is available.
* Expose scene-based segments for Home Assistant room mapping.
* Route app_segment_clean and async_clean_segments to scene_clean when using scene-based segments.
* When multiple scene-based segments are selected, clean the first scene and log a warning (matching current device capabilities).
* Add regression tests covering the new fallback behavior.

**Compatibility**

* Devices with native room support continue to use native rooms.
* The scene fallback is only used when no native rooms are available.

**Related Issues**

#130 

**Attribution**

The implementation in this PR is based on work by @acdu1. I cherry-picked the two scene-support commits from their fork so this feature can be reviewed independently of the other unrelated changes in that branch. All implementation credit goes to them.