### PR TITLE
forget_map service: prune dead maps from the Switch Map list

### DIFF
--- a/custom_components/robovac_mqtt/coordinator.py
+++ b/custom_components/robovac_mqtt/coordinator.py
@@ -984,3 +984,19 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
             len(self.last_seen_maps),
             self.device_name,
         )
+
+    async def async_forget_map(self, cloud_mapid: int) -> bool:
+        """Drop a map id from ``last_seen_maps``, persist, and refresh listeners so the
+        Switch Map selector stops offering it.
+
+        For maps that no longer exist on the device — deleted in the app or wiped by a
+        factory reset — which otherwise linger forever: the list is learn-as-seen and the
+        device exposes no authoritative map list to auto-reconcile against. Local only;
+        nothing is sent to the robot. Returns True if a map was removed.
+        """
+        if self.last_seen_maps.pop(cloud_mapid, None) is None:
+            return False
+        await self.async_save_maps()
+        self.async_update_listeners()
+        _LOGGER.debug("Forgot map %d for %s", cloud_mapid, self.device_name)
+        return True

--- a/custom_components/robovac_mqtt/services.yaml
+++ b/custom_components/robovac_mqtt/services.yaml
@@ -78,3 +78,30 @@ map_load:
         number:
           min: 0
           mode: box
+
+forget_map:
+  name: Forget map
+  description: >-
+    Remove a saved map from the "Switch Map" list. The list is learn-as-seen — the
+    integration remembers every map the robot has reported and never drops one, because
+    the device gives no authoritative list of its current maps to reconcile against. So
+    a map deleted in the app, or wiped by a factory reset, keeps showing in the selector
+    forever. Use this to prune it. Local only: nothing is sent to the robot, and the
+    map on the device is untouched. The ACTIVE map cannot be forgotten (it would
+    immediately re-appear); forgetting an id that isn't in the list does nothing.
+  target:
+    entity:
+      domain: vacuum
+      integration: robovac_mqtt
+  fields:
+    cloud_mapid:
+      name: Cloud map id
+      description: >-
+        The id of the saved map to forget, as shown in the "Switch Map" select entity
+        ("Map (ID: <id>)").
+      required: true
+      example: 7
+      selector:
+        number:
+          min: 1
+          mode: box

--- a/custom_components/robovac_mqtt/vacuum.py
+++ b/custom_components/robovac_mqtt/vacuum.py
@@ -168,6 +168,16 @@ async def async_setup_entry(
         },
         "async_map_load",
     )
+    # Prune a saved map from the learn-as-seen Switch Map list (a map deleted on the
+    # device or left over after a factory reset). Local-only; the active map can't be
+    # forgotten. See async_forget_map.
+    platform.async_register_entity_service(
+        "forget_map",
+        {
+            vol.Required("cloud_mapid"): vol.All(vol.Coerce(int), vol.Range(min=1)),
+        },
+        "async_forget_map",
+    )
 
 
 class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEntity):
@@ -493,6 +503,22 @@ class RoboVacMQTTEntity(CoordinatorEntity[EufyCleanCoordinator], StateVacuumEnti
                 "(unsupported device or invalid map id)"
             )
         await self.coordinator.async_send_command(command)
+
+    async def async_forget_map(self, cloud_mapid: int) -> None:
+        """Remove a saved map from the Switch Map list (``last_seen_maps``).
+
+        For maps that no longer exist on the device — deleted in the app or wiped by a
+        factory reset — which otherwise linger in the selector forever (the list is
+        learn-as-seen; the device exposes no authoritative map list to reconcile
+        against). Local only: nothing is sent to the robot. The ACTIVE map can't be
+        forgotten (it would immediately re-seed); forgetting an unknown id is a no-op.
+        """
+        cloud_mapid = int(cloud_mapid)
+        if cloud_mapid == self.coordinator.data.map_id:
+            raise HomeAssistantError(
+                f"Cannot forget map {cloud_mapid} — it is the active map."
+            )
+        await self.coordinator.async_forget_map(cloud_mapid)
 
     @property
     def supported_features(self) -> VacuumEntityFeature:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -227,6 +227,34 @@ def test_remember_map_id_seeds_and_dedupes(mock_hass, mock_login):
     assert coordinator.async_save_maps.call_count == 1
 
 
+@pytest.mark.asyncio
+async def test_async_forget_map_prunes_and_persists(mock_hass, mock_login):
+    """forget_map drops a known id, persists, and refreshes listeners so the Switch Map
+    selector stops offering it; an unknown id is a no-op (returns False, no extra work)."""
+    device_info = {
+        "deviceId": "test_id",
+        "deviceModel": "T2118",
+        "deviceName": "Test Vac",
+    }
+    coordinator = EufyCleanCoordinator(mock_hass, mock_login, device_info)
+    coordinator.last_seen_maps = {6: "Home", 7: "Spare", 11: ""}
+    coordinator.async_save_maps = AsyncMock()
+    coordinator.async_update_listeners = MagicMock()
+
+    removed = await coordinator.async_forget_map(6)
+    assert removed is True
+    assert coordinator.last_seen_maps == {7: "Spare", 11: ""}
+    coordinator.async_save_maps.assert_awaited_once()
+    coordinator.async_update_listeners.assert_called_once()
+
+    # Unknown id -> no removal, no extra save/refresh.
+    removed = await coordinator.async_forget_map(99)
+    assert removed is False
+    assert coordinator.last_seen_maps == {7: "Spare", 11: ""}
+    coordinator.async_save_maps.assert_awaited_once()
+    coordinator.async_update_listeners.assert_called_once()
+
+
 def test_handle_mqtt_message_seeds_startup_map(mock_hass, mock_login):
     """The map active at STARTUP is persisted even though it never arrives as a
     map_id 'change' — regression for the selector dropping it after a switch."""

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -378,4 +378,28 @@ async def test_map_load_empty_command_raises(mock_coordinator, mock_config_entry
 
     with pytest.raises(HomeAssistantError):
         await entity.async_map_load(6)
+
+
+@pytest.mark.asyncio
+async def test_forget_map_delegates_to_coordinator(mock_coordinator, mock_config_entry):
+    """Forgetting a non-active map delegates to the coordinator prune (local-only)."""
+    mock_coordinator.data.map_id = 11
+    mock_coordinator.async_forget_map = AsyncMock(return_value=True)
+    entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
+
+    await entity.async_forget_map(6)
+
+    mock_coordinator.async_forget_map.assert_awaited_once_with(6)
+
+
+@pytest.mark.asyncio
+async def test_forget_map_active_raises(mock_coordinator, mock_config_entry):
+    """The active map cannot be forgotten (it would immediately re-seed)."""
+    mock_coordinator.data.map_id = 11
+    mock_coordinator.async_forget_map = AsyncMock()
+    entity = RoboVacMQTTEntity(mock_coordinator, mock_config_entry)
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_forget_map(11)
+    mock_coordinator.async_forget_map.assert_not_called()
     mock_coordinator.async_send_command.assert_not_called()


### PR DESCRIPTION
Thanks to my Niece  who decided to press buttons and **factory reset** My X10 — no maps, no name, a full new-device state — and its first re-map got a **new** cloud map id. But the old map ids were still sitting in HA's persisted `last_seen_maps`, so the "Switch Map" selector kept offering the now-dead maps with no way to clear them, and picking one fires a `map_load` for a map that no longer exists.

### Root cause

The Switch Map list (`last_seen_maps`, added in #150) is learn-as-seen and never drops an id — the device gives no authoritative list of its current maps to reconcile against (P2P/`GET_ALL` is unavailable over cloud MQTT). So a map deleted in the app, or wiped by a factory reset, stays in the selector forever.

### Fix

Adds a **`robovac_mqtt.forget_map {cloud_mapid}`** entity service that drops the id from `last_seen_maps`, persists, and refreshes listeners so the selector stops offering it.

- **Local-only** — nothing is sent to the robot; the on-device map is untouched.
- The **active map can't be forgotten** (it would immediately re-seed); forgetting an unknown id is a no-op.

`coordinator.async_forget_map` (pop → persist → refresh) + `vacuum.async_forget_map` (active-map guard) + `services.yaml` + tests (coordinator prune/no-op, vacuum delegate/active-raises).

Independent of #157 (that's the card UI). 