### PR TITLE
Room dialog single line input -> multi line input

### DIFF
--- a/custom_components/robovac_mqtt/config_flow.py
+++ b/custom_components/robovac_mqtt/config_flow.py
@@ -407,7 +407,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_ROOM_NAMES,
                 default=_format_rooms_text(current.get(CONF_ROOM_NAMES) or {}),
             )
-        ] = cv.string
+        ] = selector.TextSelector(
+            selector.TextSelectorConfig(multiline=True)
+        )
         return self.async_show_form(
             step_id="device",
             data_schema=Schema(schema_dict),


### PR DESCRIPTION
When overriding room names, each room needs to be set on a separate line.
But the UI dialog used a string input, preventing new lines for each room.
Commit fixes this issue by switching to multiline textbox.

Existing strings input:
<img width="1914" height="937" alt="Screenshot from 2026-07-20 23-13-43" src="https://github.com/user-attachments/assets/c7a7a6bd-e7bb-4eec-890c-e3c90834e488" />


Screenshot showing updated dialog using repo docker-compose:
<img width="1914" height="937" alt="Screenshot from 2026-07-20 23-12-09" src="https://github.com/user-attachments/assets/0d37119b-7cc4-42ce-93d2-6f1b5a5d3542" />
