### PR TITLE
feat: capture and persist the full ErrorCode proto

### DIFF
--- a/custom_components/robovac_mqtt/api/legacy_parser.py
+++ b/custom_components/robovac_mqtt/api/legacy_parser.py
@@ -131,6 +131,7 @@ def _process_error_code(
     try:
         code = int(value)
         changes["error_code"] = code
+        changes["error_codes"] = [code] if code else []  # keep state shape uniform
         changes["error_message"] = EUFY_CLEAN_ERROR_CODES.get(code, f"Unknown ({code})")
         received.add("error_code")
     except (ValueError, TypeError):

--- a/custom_components/robovac_mqtt/api/parser.py
+++ b/custom_components/robovac_mqtt/api/parser.py
@@ -50,6 +50,9 @@ _LOGGER = logging.getLogger(__name__)
 
 _OFF_PEAK_RESPONSE_FIELD_NUM = 23  # UnisettingResponse field 23 = OffPeakCharging (undocumented)
 
+# ErrorCode.ObstacleReminder.Type enum -> human name (proto: POOP = 0).
+_OBSTACLE_TYPE_NAMES: dict[int, str] = {0: "poop"}
+
 
 def _extract_off_peak_charging(raw_b64: str) -> dict[str, int | bool] | None:
     """Extract off-peak charging config from raw UnisettingResponse bytes (field 23).
@@ -475,16 +478,43 @@ def _process_other_dps(
             elif key == DPS_MAP["ERROR_CODE"]:
                 error_proto = decode(ErrorCode, value)
                 _LOGGER.debug("Decoded ErrorCode: %s", error_proto)
-                # Repeated Scalar Field (warn) acts like a list
-                if len(error_proto.warn) > 0:
-                    code = error_proto.warn[0]
-                    changes["error_code"] = code
-                    changes["error_message"] = EUFY_CLEAN_ERROR_CODES.get(
-                        code, "Unknown Error"
-                    )
-                else:
-                    changes["error_code"] = 0
-                    changes["error_message"] = ""
+                # Capture the FULL proto. The old code read only warn[0] and NEVER
+                # read error[] — so real errors, simultaneous codes, timestamps,
+                # obstacle/poop reminders, and battery swaps were all discarded.
+                errors = list(error_proto.error)
+                warns = list(error_proto.warn)
+                changes["error_codes"] = errors
+                changes["warn_codes"] = warns
+                changes["last_error_time"] = int(error_proto.last_time)
+                # new_code: what the device flags as freshly reported this update
+                # (drives the coordinator's persisted error_log).
+                changes["new_error_codes"] = list(error_proto.new_code.error)
+                changes["new_warn_codes"] = list(error_proto.new_code.warn)
+                # Primary code + message: a real error[] takes priority over a warn[].
+                code = errors[0] if errors else (warns[0] if warns else 0)
+                changes["error_code"] = code
+                changes["error_message"] = (
+                    EUFY_CLEAN_ERROR_CODES.get(code, f"Unknown Error ({code})")
+                    if code
+                    else ""
+                )
+                if error_proto.battery.restored:
+                    changes["battery_restored"] = True
+                if len(error_proto.obstacle_reminder) > 0:
+                    changes["obstacle_reminders"] = [
+                        {
+                            "type": int(o.type),
+                            "type_name": _OBSTACLE_TYPE_NAMES.get(
+                                int(o.type), str(int(o.type))
+                            ),
+                            "photo_id": o.photo_id,
+                            "accuracy": o.accuracy,
+                            "map_id": o.map_id,
+                            "x": o.point.x,
+                            "y": o.point.y,
+                        }
+                        for o in error_proto.obstacle_reminder
+                    ]
 
             elif key == DPS_MAP["ACCESSORIES_STATUS"]:
                 _LOGGER.debug("Received ACCESSORIES_STATUS: %s", value)

--- a/custom_components/robovac_mqtt/api/parser_scalar.py
+++ b/custom_components/robovac_mqtt/api/parser_scalar.py
@@ -121,11 +121,17 @@ def process_scalar_dps(
                 code = _g_int(value)
                 if code:  # non-zero fault wins (106 and 177 are both candidates)
                     changes["error_code"] = code
+                    changes["error_codes"] = [code]  # keep state shape uniform
                     changes["error_message"] = EUFY_CLEAN_ERROR_CODES.get(
                         code, "Unknown Error"
                     )
+                    # Scalar has no proto new_code: treat a changed fault as fresh so
+                    # the coordinator logs it to the persisted error_log.
+                    if code != state.error_code:
+                        changes["new_error_codes"] = [code]
                 elif "error_code" not in changes:  # clear only if nothing set yet
                     changes["error_code"] = 0
+                    changes["error_codes"] = []
                     changes["error_message"] = ""
 
             elif key == SCALAR_DPS["AUTO_RETURN"]:

--- a/custom_components/robovac_mqtt/coordinator.py
+++ b/custom_components/robovac_mqtt/coordinator.py
@@ -27,6 +27,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .api.client import EufyCleanClient
 from .api.cloud import EufyLogin
@@ -61,6 +62,7 @@ _LOGGER = logging.getLogger(__name__)
 _CLOUD_POLL_INTERVAL = timedelta(seconds=30)
 _MAX_BACKOFF_INTERVAL = timedelta(minutes=5)
 _FAILURE_THRESHOLD = 5  # Raise UpdateFailed after this many consecutive failures
+_ERROR_LOG_MAX = 50  # Rolling error/warn history depth (persisted per device)
 
 
 def _px_dist(a: tuple[int, int], b: tuple[int, int]) -> float:
@@ -146,6 +148,9 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
         # frames on the biz/ stream and persisted; backs the Active Map selector.
         self.last_seen_maps: dict[int, str] = {}
         self._store = Store(hass, 1, f"{DOMAIN}.{self.device_id}")
+        # Separate store for the persisted error/warn history (the maps store
+        # clobbers to a single key on save, so errors get their own store).
+        self._error_store = Store(hass, 1, f"{DOMAIN}.{self.device_id}.errors")
         self._map_data_chan_id: int | None = None
         self._map_data: MapData | None = None
         self._robot_pixel: tuple[int, int] | None = None
@@ -319,6 +324,14 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
                 # Calculate new state based on connection
                 prev_activity = self.data.activity
                 new_state, changes = self._parse_dps(dps)
+
+                # Mine the errors we used to throw away: log fresh error/warn/
+                # obstacle/battery events to the persisted history.
+                if changes.keys() & {
+                    "error_code", "new_error_codes", "new_warn_codes",
+                    "obstacle_reminders", "battery_restored",
+                }:
+                    self._log_error_event(new_state, changes)
 
                 if "error_code" in changes:
                     if new_state.error_code != 0:
@@ -726,6 +739,51 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
         self._last_notified_error_code = 0
         pn_async_dismiss(self.hass, notification_id=f"{DOMAIN}_{self.device_id}_error")
 
+    def _log_error_event(self, new_state: VacuumState, changes: dict[str, Any]) -> None:
+        """Append a fresh error/warn event to the persisted rolling history.
+
+        "Fresh" is judged from ``changes`` (this update's delta), NOT from
+        ``new_state`` fields — the list fields carry forward across the dataclass
+        replace(), so an ongoing fault would otherwise re-log on every update.
+        Fresh means: the device flagged new_code this update (novel/scalar), the
+        primary error_code changed to a (different) non-zero fault — the backstop
+        that also covers legacy, which has no new_code — or a fresh
+        obstacle-reminder / battery-swap arrived. ``self.data`` is still the
+        PREVIOUS state here (it is reassigned later in the update cycle).
+        Mutates ``new_state.error_log`` (carried forward across updates) and
+        persists to the error store.
+        """
+        fresh = (
+            bool(changes.get("new_error_codes") or changes.get("new_warn_codes"))
+            or (
+                "error_code" in changes
+                and new_state.error_code != 0
+                and new_state.error_code != self.data.error_code
+            )
+            or "obstacle_reminders" in changes
+            or "battery_restored" in changes
+        )
+        if not fresh:
+            return
+        entry: dict[str, Any] = {
+            "time": dt_util.utcnow().isoformat(),
+            "error_code": new_state.error_code,
+            "error_message": new_state.error_message,
+            "error_codes": list(new_state.error_codes),
+            "warn_codes": list(new_state.warn_codes),
+            "device_time": new_state.last_error_time,
+        }
+        if new_state.obstacle_reminders:
+            entry["obstacle_reminders"] = new_state.obstacle_reminders
+        if new_state.battery_restored:
+            entry["battery_restored"] = True
+        new_state.error_log = ([entry] + list(new_state.error_log))[:_ERROR_LOG_MAX]
+        self.hass.async_create_task(self._async_save_error_log(list(new_state.error_log)))
+
+    async def _async_save_error_log(self, log: list[dict[str, Any]]) -> None:
+        """Persist the error history to its own store."""
+        await self._error_store.async_save({"error_log": log})
+
     def async_shutdown_timers(self) -> None:
         """Cancel active debounce timers (call before teardown)."""
         if self._dock_idle_cancel:
@@ -865,6 +923,14 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
 
     async def async_load_storage(self) -> None:
         """Load data from storage."""
+        # Persisted error/warn history (its own store).
+        if edata := await self._error_store.async_load():
+            self.data.error_log = list(edata.get("error_log") or [])
+            _LOGGER.debug(
+                "Loaded %d error-log entries for %s",
+                len(self.data.error_log),
+                self.device_name,
+            )
         if data := await self._store.async_load():
             self.last_seen_segments = data.get("last_seen_segments")
             _LOGGER.debug(

--- a/custom_components/robovac_mqtt/models.py
+++ b/custom_components/robovac_mqtt/models.py
@@ -49,8 +49,23 @@ class VacuumState:
     fan_speed: str = "Standard"
 
     # Error state
-    error_code: int = 0
+    error_code: int = 0          # primary code (a real error[] wins over a warn[])
     error_message: str = ""
+    # Full ErrorCode proto capture — the novel parser previously read only warn[0]
+    # and NEVER read error[]. Lists so simultaneous codes are preserved.
+    error_codes: list[int] = field(default_factory=list)   # proto error[]
+    warn_codes: list[int] = field(default_factory=list)    # proto warn[]
+    last_error_time: int = 0                                # proto last_time (ns, monotonic)
+    # proto new_code — codes the device flags as FRESHLY reported this update; the
+    # coordinator uses these to append to the persisted error_log.
+    new_error_codes: list[int] = field(default_factory=list)
+    new_warn_codes: list[int] = field(default_factory=list)
+    battery_restored: bool = False                          # proto battery.restored
+    # proto obstacle_reminder[]: [{type, type_name, photo_id, accuracy, map_id, x, y}]
+    obstacle_reminders: list[dict[str, Any]] = field(default_factory=list)
+    # Persisted rolling history of error/warn events (managed + stored by the
+    # coordinator, mirrored here so entities can read it). Newest first.
+    error_log: list[dict[str, Any]] = field(default_factory=list)
     charging: bool = False
 
     # Cleaning Stats

--- a/custom_components/robovac_mqtt/sensor.py
+++ b/custom_components/robovac_mqtt/sensor.py
@@ -82,6 +82,16 @@ async def async_setup_entry(
                 state_class=None,
                 icon="mdi:alert-circle-outline",
                 category=EntityCategory.DIAGNOSTIC,
+                # Full mined ErrorCode data + persisted history as attributes.
+                extra_state_attributes_fn=lambda s: {
+                    "error_code": s.error_code,
+                    "error_codes": s.error_codes,
+                    "warn_codes": s.warn_codes,
+                    "last_error_time": s.last_error_time,
+                    "obstacle_reminders": s.obstacle_reminders,
+                    "battery_restored": s.battery_restored,
+                    "history": s.error_log,
+                },
             ),
             # Task Status Sensor
             RoboVacSensor(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -86,16 +86,18 @@ def test_update_state_error_code(mock_decode):
     """Test updating error code."""
     state = VacuumState()
 
-    # Mock ErrorCode
-    mock_error = MagicMock(spec=ErrorCode)
-    mock_error.warn = [1]  # CRASH BUFFER STUCK
-    mock_decode.return_value = mock_error
+    # Real ErrorCode proto — the parser now reads error[]/new_code/battery/
+    # obstacle_reminder, so a bare MagicMock(spec=ErrorCode) is insufficient.
+    error = ErrorCode()
+    error.warn.append(1)  # CRASH BUFFER STUCK
+    mock_decode.return_value = error
 
     dps = {DPS_MAP["ERROR_CODE"]: "some_encoded_string"}
     new_state, _ = update_state(state, dps)
 
     assert new_state.error_code == 1
     assert new_state.error_message == "CRASH BUFFER STUCK"
+    assert new_state.warn_codes == [1]
 
 
 @patch("custom_components.robovac_mqtt.api.parser.decode")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,7 +10,10 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from custom_components.robovac_mqtt.api.map_stream import MapData
-from custom_components.robovac_mqtt.coordinator import EufyCleanCoordinator
+from custom_components.robovac_mqtt.coordinator import (
+    _ERROR_LOG_MAX,
+    EufyCleanCoordinator,
+)
 from custom_components.robovac_mqtt.models import VacuumState
 
 
@@ -659,3 +662,114 @@ async def test_cloud_poll_backoff_caps_at_max(mock_hass, mock_login):
         await coordinator._async_update_data()
 
     assert coordinator.update_interval <= timedelta(minutes=5)
+
+
+# ---------------------------------------------------------------------------
+# Persisted error/warn history (the errors eufy-clean used to throw away)
+# ---------------------------------------------------------------------------
+
+
+def _make_error_coordinator(mock_hass, mock_login):
+    """A novel coordinator with the error store stubbed out (no real I/O)."""
+    device_info = {
+        "deviceId": "err_dev",
+        "deviceModel": "T2118",
+        "deviceName": "Err Vac",
+    }
+    coordinator = EufyCleanCoordinator(mock_hass, mock_login, device_info)
+    # Don't touch the real Store; just record that a save was requested.
+    coordinator._async_save_error_log = MagicMock()
+    coordinator.data = VacuumState()
+    return coordinator
+
+
+def test_log_error_event_records_fresh_fault(mock_hass, mock_login):
+    """A fresh fault is appended to the history, newest-first, and saved."""
+    coordinator = _make_error_coordinator(mock_hass, mock_login)
+
+    new_state = VacuumState(
+        error_code=177, error_codes=[177], warn_codes=[],
+        new_error_codes=[177], error_message="STATION DIRTY",
+    )
+    coordinator._log_error_event(
+        new_state, {"error_code": 177, "new_error_codes": [177]}
+    )
+
+    assert len(new_state.error_log) == 1
+    assert new_state.error_log[0]["error_code"] == 177
+    assert new_state.error_log[0]["error_message"] == "STATION DIRTY"
+    assert coordinator._async_save_error_log.call_count == 1
+
+
+def test_log_error_event_dedupes_ongoing_fault(mock_hass, mock_login):
+    """The same fault re-reported on later updates is NOT re-logged.
+
+    In the scalar path ``new_error_codes`` carries forward on the state but is
+    absent from ``changes`` once the fault stops being fresh — the guard must
+    read ``changes``, not the carried-forward state field.
+    """
+    coordinator = _make_error_coordinator(mock_hass, mock_login)
+
+    s1 = VacuumState(error_code=177, error_codes=[177], new_error_codes=[177])
+    coordinator._log_error_event(s1, {"error_code": 177, "new_error_codes": [177]})
+    assert len(s1.error_log) == 1
+
+    # Advance: the fault is now the current (previous) state.
+    coordinator.data = s1
+    # Same fault still active — new_error_codes carried forward on the state,
+    # but changes only carries error_code (unchanged value).
+    s2 = VacuumState(
+        error_code=177, error_codes=[177], new_error_codes=[177],
+        error_log=list(s1.error_log),
+    )
+    coordinator._log_error_event(s2, {"error_code": 177})
+    assert len(s2.error_log) == 1  # not re-logged
+    assert coordinator._async_save_error_log.call_count == 1  # only the first
+
+
+def test_log_error_event_legacy_transition_backstop(mock_hass, mock_login):
+    """Legacy has no new_code: a clear->fault transition is still logged."""
+    coordinator = _make_error_coordinator(mock_hass, mock_login)
+
+    new_state = VacuumState(error_code=106, error_codes=[106])
+    coordinator._log_error_event(new_state, {"error_code": 106})  # no new_error_codes
+    assert len(new_state.error_log) == 1
+    assert new_state.error_log[0]["error_code"] == 106
+
+
+def test_log_error_event_records_obstacle_and_battery(mock_hass, mock_login):
+    """Obstacle (poop) reminders and battery swaps are logged even with no fault."""
+    coordinator = _make_error_coordinator(mock_hass, mock_login)
+
+    obstacle = {"type": 0, "type_name": "poop", "photo_id": "p1",
+                "accuracy": 90, "map_id": 2, "x": 100, "y": 200}
+    new_state = VacuumState(
+        obstacle_reminders=[obstacle], battery_restored=True,
+    )
+    coordinator._log_error_event(
+        new_state,
+        {"obstacle_reminders": [obstacle], "battery_restored": True},
+    )
+    assert len(new_state.error_log) == 1
+    entry = new_state.error_log[0]
+    assert entry["obstacle_reminders"][0]["type_name"] == "poop"
+    assert entry["battery_restored"] is True
+
+
+def test_log_error_event_caps_history(mock_hass, mock_login):
+    """The rolling history is capped at _ERROR_LOG_MAX, newest-first."""
+    coordinator = _make_error_coordinator(mock_hass, mock_login)
+    log: list = []
+    for code in range(_ERROR_LOG_MAX + 10):
+        state = VacuumState(
+            error_code=code + 1, error_codes=[code + 1],
+            new_error_codes=[code + 1], error_log=log,
+        )
+        coordinator._log_error_event(
+            state, {"error_code": code + 1, "new_error_codes": [code + 1]}
+        )
+        log = state.error_log
+
+    assert len(log) == _ERROR_LOG_MAX
+    # Newest entry (highest code) is first.
+    assert log[0]["error_code"] == _ERROR_LOG_MAX + 10

--- a/tests/test_error_parsing.py
+++ b/tests/test_error_parsing.py
@@ -17,3 +17,54 @@ def test_error_code_mapping():
     new_state, _ = update_state(state, dps)
     assert new_state.error_code == 6011
     assert new_state.error_message == "STATION LOW CLEAN WATER"
+    # The full warn list is now captured too (not just [0]).
+    assert new_state.warn_codes == [6011]
+
+
+def test_full_error_capture():
+    """The whole ErrorCode proto is mined: error[] (previously NEVER read), the
+    full warn[], timestamp, new_code, obstacle/poop reminder, and battery swap."""
+    state = VacuumState()
+    error = ErrorCode()
+    error.error.extend([101, 102])        # real errors — the old parser ignored these
+    error.warn.extend([6011, 6012])       # multiple warnings
+    error.last_time = 123456789
+    error.new_code.error.append(101)
+    error.new_code.warn.append(6011)
+    error.battery.restored = True
+    ob = error.obstacle_reminder.add()
+    ob.type = 0                           # POOP
+    ob.photo_id = "photo123"
+    ob.accuracy = 88
+    ob.map_id = 3
+    ob.point.x = 150
+    ob.point.y = -200
+    dps = {DPS_MAP["ERROR_CODE"]: encode_message(error)}
+
+    new_state, _ = update_state(state, dps)
+    # A real error[] takes priority over a warn[] for the primary code.
+    assert new_state.error_code == 101
+    assert new_state.error_codes == [101, 102]
+    assert new_state.warn_codes == [6011, 6012]
+    assert new_state.last_error_time == 123456789
+    assert new_state.new_error_codes == [101]
+    assert new_state.new_warn_codes == [6011]
+    assert new_state.battery_restored is True
+    assert len(new_state.obstacle_reminders) == 1
+    ob0 = new_state.obstacle_reminders[0]
+    assert ob0["type_name"] == "poop"
+    assert ob0["photo_id"] == "photo123"
+    assert ob0["accuracy"] == 88
+    assert ob0["map_id"] == 3
+    assert ob0["x"] == 150 and ob0["y"] == -200
+
+
+def test_error_clears_to_empty():
+    """An empty ErrorCode clears the primary code and the lists."""
+    state = VacuumState(error_code=101, error_codes=[101], warn_codes=[6011])
+    dps = {DPS_MAP["ERROR_CODE"]: encode_message(ErrorCode())}
+    new_state, _ = update_state(state, dps)
+    assert new_state.error_code == 0
+    assert new_state.error_message == ""
+    assert new_state.error_codes == []
+    assert new_state.warn_codes == []


### PR DESCRIPTION
## Summary
The novel MQTT parser decodes the `ErrorCode` protobuf but only ever read `warn[0]`. It never read the `error[]` array, the event timestamp, `new_code`, obstacle reminders, or battery-swap events — all of which arrive on the error frame and were discarded. This PR captures the whole proto and persists a rolling per-device history that survives restarts.

## Motivation
On some devices (verified on an Omni/X-series unit), operational faults are reported through `error[]`, not `warn[]`. Because the parser never read `error[]`, `error_message` stayed permanently empty for those faults. Concretely: lifting the robot reports code `7002` ("MACHINE PICKED UP") in `error[]`, which the current parser resolves to `error_code = 0` and an empty message — so the fault is invisible.

## Changes
- **Parsers** — the novel parser now decodes `error[]`, `warn[]`, `last_time`, `new_code.{error,warn}`, `battery.restored`, and `obstacle_reminder[]` (type / photo_id / accuracy / map_id / point). The primary `error_code` prefers a real `error[]` over a `warn[]`. The scalar and legacy parsers mirror `error_codes[]` so state shape is uniform across transports.
- **State** — `VacuumState` gains `error_codes`, `warn_codes`, `last_error_time`, `new_error_codes`, `new_warn_codes`, `battery_restored`, `obstacle_reminders`, and `error_log`. All additive with empty defaults; no breaking changes.
- **Coordinator** — a per-device `Store` (separate from the maps store) keeps the last 50 events, newest-first, loaded on startup. "Freshness" is judged from the per-update delta, not carried-forward state, so an ongoing fault is logged once rather than every tick; a clear→fault transition is a backstop for transports without `new_code`.
- **Sensor** — the Error Message sensor exposes the mined fields plus the full history as attributes.

## Testing
Added unit tests: full-proto capture, `error[]`-over-`warn[]` priority, clear-to-empty, dedup of an ongoing fault, the legacy transition backstop, obstacle/battery logging, and the history cap. Full suite: 546 passing. pre-commit (pyupgrade / codespell / flake8 / isort / mypy / pylint) clean.

## Live validation
On real hardware: lift → `7002` in `error_codes[]`; pulling the station tanks → `6010` / `6025` in `warn_codes[]`; all persisted with timestamps and resolved labels.

## Notes
- The `manifest.json` version is intentionally left unchanged — `release_version_check` runs only on release tags, so the version bump is a maintainer/release step.
