### PR TITLE
feat: Room cleaning over legacy API

### DIFF
--- a/custom_components/robovac_mqtt/api/legacy_commands.py
+++ b/custom_components/robovac_mqtt/api/legacy_commands.py
@@ -6,7 +6,10 @@ Only a subset of novel commands are supported.
 
 from __future__ import annotations
 
+import base64
+import json
 import logging
+import time
 from typing import Any
 
 from ..const import LEGACY_CLEAN_SPEEDS, LEGACY_DPS_MAP
@@ -76,15 +79,29 @@ def _build_clean_spot(**kwargs: Any) -> dict[str, Any]:
 
 def _build_room_clean(**kwargs: Any) -> dict[str, Any]:
     """Legacy room clean — no room IDs supported, just sets mode."""
+
     if kwargs.get("room_ids"):
+        payload_dict = {
+            "method": "selectRoomsClean",
+            "data": {
+                "roomIds": kwargs["room_ids"],
+                "count": 1
+            },
+            "timestamp": round(time.time() * 1000),
+        }
+
+        payload_json = json.dumps(payload_dict, separators=(",", ":"))
+        base64_str = base64.b64encode(payload_json.encode("utf8")).decode("utf8")
+
         _LOGGER.warning(
-            "room_clean: room_ids parameter is not supported on legacy devices; "
-            "starting full room clean instead"
+            "room_clean: room_ids parameter may not be supported on legacy devices."
         )
-    return {
-        LEGACY_DPS_MAP["PLAY_PAUSE"]: True,
-        LEGACY_DPS_MAP["WORK_MODE"]: "room",
-    }
+        return {
+            LEGACY_DPS_MAP["CLEAN_ROOM"]: base64_str,
+            LEGACY_DPS_MAP["PLAY_PAUSE"]: True,
+            LEGACY_DPS_MAP["WORK_MODE"]: "room",
+        }
+    return {}
 
 
 def _build_edge_clean(**kwargs: Any) -> dict[str, Any]:

--- a/custom_components/robovac_mqtt/api/legacy_commands.py
+++ b/custom_components/robovac_mqtt/api/legacy_commands.py
@@ -78,8 +78,6 @@ def _build_clean_spot(**kwargs: Any) -> dict[str, Any]:
 
 
 def _build_room_clean(**kwargs: Any) -> dict[str, Any]:
-    """Legacy room clean — no room IDs supported, just sets mode."""
-
     if kwargs.get("room_ids"):
         payload_dict = {
             "method": "selectRoomsClean",
@@ -101,7 +99,10 @@ def _build_room_clean(**kwargs: Any) -> dict[str, Any]:
             LEGACY_DPS_MAP["PLAY_PAUSE"]: True,
             LEGACY_DPS_MAP["WORK_MODE"]: "room",
         }
-    return {}
+    return {
+        LEGACY_DPS_MAP["PLAY_PAUSE"]: True,
+        LEGACY_DPS_MAP["WORK_MODE"]: "room",
+    }
 
 
 def _build_edge_clean(**kwargs: Any) -> dict[str, Any]:

--- a/custom_components/robovac_mqtt/const.py
+++ b/custom_components/robovac_mqtt/const.py
@@ -744,6 +744,7 @@ LEGACY_DPS_MAP = {
     "FIND_ROBOT": "103",
     "BATTERY_LEVEL": "104",
     "ERROR_CODE": "106",
+    "CLEAN_ROOM": "124",
 }
 
 # Reverse lookup: DPS number string -> key name

--- a/tests/test_legacy_commands.py
+++ b/tests/test_legacy_commands.py
@@ -5,6 +5,7 @@ import logging
 import pytest
 
 from custom_components.robovac_mqtt.api.legacy_commands import build_legacy_command
+from custom_components.robovac_mqtt.const import LEGACY_DPS_MAP
 
 # ── Basic commands ──────────────────────────────────────────────────
 
@@ -102,27 +103,24 @@ def test_edge_clean():
     assert result == {"2": True, "5": "Edge"}
 
 
-# ── Room clean with room_ids warning ──────────────────────────────
+# ── Room clean with room_ids ──────────────────────────────
 
 
-def test_room_clean_with_room_ids_logs_warning(caplog):
-    """room_clean should warn when room_ids are passed (unsupported on legacy)."""
-    with caplog.at_level(logging.WARNING):
-        result = build_legacy_command("room_clean", room_ids=[1, 2, 3])
+def test_room_clean_with_room_ids():
+    """room_clean should return the room ids in the encoded payload."""
+    import base64
+    import json
 
-    # Command should still work (full room clean)
+    room_ids = [1,2,3]
+    result = build_legacy_command("room_clean", room_ids=room_ids)
+
+    # result should contain the base64 encoded room_ids
+    assert LEGACY_DPS_MAP["CLEAN_ROOM"] in result
+    room_command_str = base64.decodebytes(result.pop(LEGACY_DPS_MAP["CLEAN_ROOM"]).encode()).decode()
+    room_command_dict = json.loads(room_command_str)
+
+    assert room_command_dict["data"]["roomIds"] == room_ids
     assert result == {"2": True, "5": "room"}
-    assert "room_ids parameter is not supported on legacy devices" in caplog.text
-
-
-def test_room_clean_without_room_ids_no_warning(caplog):
-    """room_clean without room_ids should not warn."""
-    with caplog.at_level(logging.WARNING):
-        result = build_legacy_command("room_clean")
-
-    assert result == {"2": True, "5": "room"}
-    assert "room_ids" not in caplog.text
-
 
 # ── Unsupported commands ────────────────────────────────────────────
 


### PR DESCRIPTION
# Problem

Room cleaning in the legacy API is explicitly blocked, despite it being a feature on some models of Eufy vacuum (DPS ID: 124)

# Fix

Taking the logic from one of the [eufy robovac](https://github.com/CodeFoodPixels/robovac/blob/main/custom_components/robovac/vacuum.py#L434) integrations, it's possible to encode the room cleaning request and pass it to the device over the local legacy API.

Tested on an LR30 (T2193) using the Room Clean drop-down in the device page.