### PR TITLE
feat: room list and live map over the local P2P channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Room segments with guaranteed unique names (duplicates auto-suffixed, e.g. `Kitc
 | C-Series | T1250, T2117, T2118, T2120, T2128, T2130, T2132, T2280, T2292 (C20, C28 Omni) |
 | L-Series | T2190, T2267, T2268, T2278 (L60, L70) |
 | G-Series | T2210–T2278 (G20, G30, G35, G40, G50) |
-| S-Series | T2119, T2080 (RoboVac 11S, S1) |
+| S-Series | T2119, T2080, T2080A (RoboVac 11S, S1, S1 Pro) |
 
 ---
 
@@ -195,19 +195,21 @@ unavailable just because the LAN address has shifted.
 > integration debug logs that might contain it into public issues.
 
 > [!NOTE]
-> Live map and live X/Y position are **not** available over either Tuya
-> transport — Eufy delivers them through a separate encrypted P2P channel
-> (`eufy_mega` SDK) that no public reverse-engineering has cracked yet.
-> Everything else — vacuum/mop mode, water level, clean count, spot/zone/room
-> commands, station status, consumables, lifetime stats, all sensors —
-> works fine over both transports.
+> On Tuya-transport devices the map and room list are not on MQTT; they ride an
+> encrypted local P2P channel. This integration now opens and decodes that
+> channel, so the room list and the floor-map camera work on Tuya devices too
+> (verified end to end on the S1 Pro, T2080A). Live X/Y position and cleaning
+> path ride the same channel and are reachable, but are not exposed as entities
+> yet. See `docs/P2P_MAP_CHANNEL.md`. Everything else (vacuum/mop mode, water
+> level, clean count, spot/zone/room commands, station status, consumables,
+> lifetime stats, all sensors) works over both transports.
 
 ### Optional: Manual room name overrides
 
-The room list (and the `select.robovac_clean_room` entity that targets it)
-normally comes from the same encrypted P2P channel as the map, so on Tuya
-transports the dropdown is empty. If you'd like to drive room cleaning from
-HA anyway, you can supply your own `room_id: name` mapping:
+The room list (and the `select.robovac_clean_room` entity that targets it) is
+fetched automatically over the local P2P channel on Tuya devices. If that path
+is unavailable (no Tuya cloud session, or a device that does not answer), you can
+supply your own `room_id: name` mapping instead:
 
 1.  Settings → Devices & Services → **Eufy Robovac MQTT** → **Configure**.
 2.  In the **Rooms** field for your vacuum, enter one room per line:

--- a/custom_components/robovac_mqtt/api/p2p/__init__.py
+++ b/custom_components/robovac_mqtt/api/p2p/__init__.py
@@ -7,6 +7,6 @@ the S1 Pro). See ``docs/P2P_MAP_CHANNEL.md`` for the protocol.
 
 from __future__ import annotations
 
-from .session import fetch_rooms
+from .session import fetch_rooms, fetch_snapshot
 
-__all__ = ["fetch_rooms"]
+__all__ = ["fetch_rooms", "fetch_snapshot"]

--- a/custom_components/robovac_mqtt/api/p2p/__init__.py
+++ b/custom_components/robovac_mqtt/api/p2p/__init__.py
@@ -1,0 +1,12 @@
+"""Local, encrypted Tuya P2P client.
+
+Opens the P2P map channel on the LAN with the device local key and returns the
+room list for robots that expose it nowhere else (``mqtt=False`` devices such as
+the S1 Pro). See ``docs/P2P_MAP_CHANNEL.md`` for the protocol.
+"""
+
+from __future__ import annotations
+
+from .session import fetch_rooms
+
+__all__ = ["fetch_rooms"]

--- a/custom_components/robovac_mqtt/api/p2p/control.py
+++ b/custom_components/robovac_mqtt/api/p2p/control.py
@@ -1,0 +1,47 @@
+"""The conversation-0 control burst that makes the robot start streaming the map.
+
+The first packet authenticates: ``magic | type | username[32] | credential[32] |
+reserved[32]``, where ``credential = md5(device_password + "||" + local_key)``.
+The packets that follow it (a hello and the subscription to the map/path streams)
+are fixed for this robot family and carry no secrets, so they are embedded
+verbatim. The device answers each on conversation 0 and then opens conversation 5.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+_MAGIC = (0x12345678).to_bytes(4, "little")
+_AUTH_TYPE = (0).to_bytes(4, "little")
+_FIELD = 32
+_USERNAME = "admin"
+
+# Fixed conversation-0 packets captured from an S1 Pro (no secrets: a hello naming
+# the peer, then a subscription to map.bin.stream / cleanPath.bin.stream /
+# navPath.bin.stream, then a short follow-up).
+_HELLO = bytes.fromhex(
+    "78563412020000000000000064000c0074000000ffffffff6970635f737765657065725f726f626f740000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+)
+_SUBSCRIBE = bytes.fromhex(
+    "78563412030001000000000064000d00d000000005000000000000006970635f737765657065725f726f626f740000000000000000000000000000000000000000000000000000000000000000000000030000006d61702e62696e2e73747265616d00000000000000000000000000000000000000000000000000000000000000000000636c65616e506174682e62696e2e73747265616d000000000000000000000000000000000000000000000000000000006e6176506174682e62696e2e73747265616d000000000000000000000000000000000000000000000000000000000000"
+)
+_FOLLOW_UP = bytes.fromhex(
+    "78563412040000000000000064000d0048000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+)
+
+
+def auth_credential(device_password: str, local_key: str) -> str:
+    """Return the conversation-0 auth token, ``md5(password + "||" + localKey)``."""
+    return hashlib.md5(f"{device_password}||{local_key}".encode(), usedforsecurity=False).hexdigest()
+
+
+def _auth_packet(credential: str) -> bytes:
+    body = bytearray(_FIELD * 3)
+    body[0 : len(_USERNAME)] = _USERNAME.encode()
+    body[_FIELD : _FIELD + len(credential)] = credential.encode()
+    return _MAGIC + _AUTH_TYPE + bytes(body)
+
+
+def start_packets(device_password: str, local_key: str) -> list[bytes]:
+    """Return the ordered conversation-0 packets, ready to wrap as KCP records."""
+    return [_auth_packet(auth_credential(device_password, local_key)), _HELLO, _SUBSCRIBE, _FOLLOW_UP]

--- a/custom_components/robovac_mqtt/api/p2p/framing.py
+++ b/custom_components/robovac_mqtt/api/p2p/framing.py
@@ -1,0 +1,92 @@
+"""Tuya local protocol 3.3 framing for the P2P signaling (command type 32).
+
+The signaling that sets up a P2P session (SDP offer/answer, ICE candidates) rides
+the same local TCP 6668 connection as normal DPS control, but on Tuya command
+type ``32``. Unlike a DP write, a type-32 frame carries **no** "3.3" extended
+header: its body is just the JSON, AES-ECB encrypted under the device local key.
+Adding the header makes the device answer ``"parse data error"``.
+
+Only the little that P2P needs is implemented here, so the module stays free of
+any ``tinytuya`` version quirks around unknown command bytes.
+"""
+
+from __future__ import annotations
+
+import json
+import zlib
+from typing import Any
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+PREFIX = 0x000055AA
+SUFFIX = 0x0000AA55
+
+CMD_DP_QUERY = 0x0A
+CMD_RTC = 0x20  # command type 32: P2P / "thing.m.rtc" signaling
+
+
+def _aes_ecb_encrypt(key: bytes, data: bytes) -> bytes:
+    pad = 16 - (len(data) % 16)
+    data += bytes([pad]) * pad
+    enc = Cipher(algorithms.AES(key), modes.ECB()).encryptor()
+    return enc.update(data) + enc.finalize()
+
+
+def _aes_ecb_decrypt(key: bytes, data: bytes) -> bytes:
+    dec = Cipher(algorithms.AES(key), modes.ECB()).decryptor()
+    out = dec.update(data) + dec.finalize()
+    if out and 1 <= out[-1] <= 16:
+        out = out[: -out[-1]]
+    return out
+
+
+def encode_frame(local_key: bytes, command: int, payload: dict[str, Any] | bytes, sequence: int) -> bytes:
+    """Encode one Tuya 3.3 local frame (no 3.3 header, as type-32 uses)."""
+    body = payload if isinstance(payload, bytes) else json.dumps(payload, separators=(",", ":")).encode()
+    body = _aes_ecb_encrypt(local_key, body)
+    frame = bytearray()
+    frame += PREFIX.to_bytes(4, "big")
+    frame += sequence.to_bytes(4, "big")
+    frame += command.to_bytes(4, "big")
+    frame += (len(body) + 8).to_bytes(4, "big")
+    frame += body
+    frame += (zlib.crc32(bytes(frame)) & 0xFFFFFFFF).to_bytes(4, "big")
+    frame += SUFFIX.to_bytes(4, "big")
+    return bytes(frame)
+
+
+def decode_frames(local_key: bytes, buffer: bytes) -> tuple[list[tuple[int, Any]], bytes]:
+    """Decode every whole frame in ``buffer``.
+
+    Returns the decoded ``(command, payload)`` pairs and the unconsumed tail.
+    A type-32 payload comes back as a parsed JSON object; anything else as bytes.
+    """
+    out: list[tuple[int, Any]] = []
+    pos = 0
+    marker = PREFIX.to_bytes(4, "big")
+    while True:
+        start = buffer.find(marker, pos)
+        if start < 0 or start + 16 > len(buffer):
+            break
+        length = int.from_bytes(buffer[start + 12 : start + 16], "big")
+        end = start + 16 + length
+        if end > len(buffer):
+            break
+        command = int.from_bytes(buffer[start + 8 : start + 12], "big")
+        body = buffer[start + 16 : end - 8]  # drop crc(4) + suffix(4)
+        # Device-originated frames carry a 4-byte return code before the encrypted
+        # payload; the ciphertext is block-aligned, so a 4-byte remainder is it.
+        if len(body) % 16 == 4:
+            body = body[4:]
+        payload: Any = body
+        if body:
+            try:
+                plain = _aes_ecb_decrypt(local_key, body)
+                if plain[:3] == b"3.3":
+                    plain = plain[15:]
+                payload = json.loads(plain)
+            except Exception:  # noqa: BLE001 - non-JSON frames (status, heartbeat) are ignored
+                payload = body
+        out.append((command, payload))
+        pos = end
+    return out, buffer[pos:]

--- a/custom_components/robovac_mqtt/api/p2p/kcp.py
+++ b/custom_components/robovac_mqtt/api/p2p/kcp.py
@@ -1,0 +1,82 @@
+"""KCP segments and their per-segment integrity tag.
+
+The media rides KCP over the UDP pair. Each data segment is followed by a 20-byte
+``HMAC-SHA1(media_key, segment)`` tag covering the whole segment; the device
+silently drops any data segment whose tag is missing or wrong. ACK segments carry
+no tag. A segment's ``len`` field counts the record **including** its 16-byte IV,
+so the ciphertext is ``len - 16`` bytes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import struct
+from dataclasses import dataclass
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+HEADER_LENGTH = 24
+TAG_LENGTH = 20
+
+CMD_PUSH = 0x51
+CMD_ACK = 0x52
+
+CONV_CONTROL = 0
+CONV_MAP = 5
+
+
+@dataclass(frozen=True, slots=True)
+class Segment:
+    conversation: int
+    command: int
+    timestamp: int
+    sequence: int
+    unacknowledged: int
+    data: bytes
+
+
+def _record(media_key: bytes, plaintext: bytes) -> bytes:
+    iv = os.urandom(16)
+    pad = 16 - (len(plaintext) % 16)
+    plaintext += bytes([pad]) * pad
+    enc = Cipher(algorithms.AES(media_key), modes.CBC(iv)).encryptor()
+    return iv + enc.update(plaintext) + enc.finalize()
+
+
+def decrypt_record(media_key: bytes, record: bytes) -> bytes:
+    """Decrypt one ``IV | AES-CBC`` record and strip PKCS#7 padding."""
+    iv, ciphertext = record[:16], record[16:]
+    dec = Cipher(algorithms.AES(media_key), modes.CBC(iv)).decryptor()
+    plain = dec.update(ciphertext) + dec.finalize()
+    if plain and 1 <= plain[-1] <= 16:
+        plain = plain[: -plain[-1]]
+    return plain
+
+
+def build_push(media_key: bytes, conversation: int, sequence: int, plaintext: bytes) -> bytes:
+    data = _record(media_key, plaintext)
+    header = struct.pack("<IBBHIIII", conversation, CMD_PUSH, 0, 512, 0, sequence, 0, len(data))
+    segment = header + data
+    return segment + hmac.new(media_key, segment, hashlib.sha1).digest()
+
+
+def build_ack(conversation: int, sequence: int, receive_next: int) -> bytes:
+    return struct.pack("<IBBHIIII", conversation, CMD_ACK, 0, 512, 0, sequence, receive_next, 0)
+
+
+def parse_datagram(datagram: bytes) -> list[Segment]:
+    """Split one UDP datagram into its stacked KCP segments."""
+    segments: list[Segment] = []
+    pos = 0
+    while pos + HEADER_LENGTH <= len(datagram):
+        conv, cmd, _frg, _wnd, ts, sn, una, length = struct.unpack("<IBBHIIII", datagram[pos : pos + HEADER_LENGTH])
+        if cmd == CMD_PUSH:
+            data = datagram[pos + HEADER_LENGTH : pos + HEADER_LENGTH + length]
+            segments.append(Segment(conv, cmd, ts, sn, una, data))
+            pos += HEADER_LENGTH + length + TAG_LENGTH
+        else:
+            segments.append(Segment(conv, cmd, ts, sn, una, b""))
+            pos += HEADER_LENGTH
+    return segments

--- a/custom_components/robovac_mqtt/api/p2p/mapdata.py
+++ b/custom_components/robovac_mqtt/api/p2p/mapdata.py
@@ -1,0 +1,70 @@
+"""Reassemble the conversation-5 byte stream and pull the room list out of it.
+
+The stream is a sequence of chunks: an 80-byte header (a constant ``1`` marker, a
+constant ``1000``, a session counter, a chunk index, a 48-byte stream name, the
+chunk payload length, the object's total length) followed by the payload. Objects
+larger than one chunk span several chunks of the same stream name. Each assembled
+``map.bin.stream`` object is a length-delimited ``MapChannelMsg``; the one whose
+``msg_type`` is ``ROOM_PARAMS`` carries the rooms.
+"""
+
+from __future__ import annotations
+
+import struct
+
+from google.protobuf.internal.decoder import _DecodeVarint
+
+from ...proto.cloud.p2pdata_pb2 import MapChannelMsg, MapInfo
+
+_HEADER_LENGTH = 80
+_SYNC = struct.pack("<II", 1, 1000)  # fields at offsets 0 and 4, used to find each header
+_ROOM_PARAMS = MapInfo.ROOM_PARAMS
+_MAP_INFO = MapChannelMsg.MAP_INFO
+_MAP_STREAM = b"map.bin.stream"
+
+
+def _iter_objects(stream: bytes):
+    """Yield each ``(stream_name, object_bytes)`` reassembled from the chunk stream."""
+    pos = stream.find(_SYNC)
+    current_name: bytes | None = None
+    buffer = b""
+    total = 0
+    while pos >= 0 and pos + _HEADER_LENGTH <= len(stream):
+        name = stream[pos + 20 : pos + 68].split(b"\x00", 1)[0]
+        payload_length, object_total = struct.unpack("<II", stream[pos + 68 : pos + 76])
+        payload = stream[pos + _HEADER_LENGTH : pos + _HEADER_LENGTH + payload_length]
+        if current_name != name or len(buffer) >= total:
+            if current_name is not None and len(buffer) == total:
+                yield current_name, buffer
+            current_name, buffer, total = name, b"", object_total
+        buffer += payload
+        if len(buffer) == total:
+            yield current_name, buffer
+            current_name = None
+        nxt = stream.find(_SYNC, pos + _HEADER_LENGTH + payload_length)
+        pos = nxt
+    if current_name is not None and len(buffer) == total:
+        yield current_name, buffer
+
+
+def _decode_delimited(buffer: bytes) -> MapChannelMsg:
+    length, start = _DecodeVarint(buffer, 0)
+    message = MapChannelMsg()
+    message.ParseFromString(buffer[start : start + length])
+    return message
+
+
+def extract_rooms(stream: bytes) -> list[dict] | None:
+    """Return ``[{"id", "name"}, ...]`` from the first ``ROOM_PARAMS`` object, or None."""
+    for name, obj in _iter_objects(stream):
+        if name != _MAP_STREAM:
+            continue
+        try:
+            message = _decode_delimited(obj)
+        except Exception:  # noqa: BLE001 - skip anything that is not a whole MapChannelMsg
+            continue
+        info = message.map_info
+        if message.type != _MAP_INFO or info.msg_type != _ROOM_PARAMS:
+            continue
+        return [{"id": room.id, "name": room.name} for room in info.room_params.rooms]
+    return None

--- a/custom_components/robovac_mqtt/api/p2p/mapimage.py
+++ b/custom_components/robovac_mqtt/api/p2p/mapimage.py
@@ -1,0 +1,92 @@
+"""Build a renderable ``MapData`` from the P2P map stream.
+
+The renderer (``map_stream.render_map_png``) wants a real-time ``raw_pixels``
+base (2 bits per pixel) plus an optional room-outline overlay (1 byte per pixel,
+high 6 bits = room id). The device pushes both as ``MapChannelMsg`` objects, but
+only streams the real-time map while it is moving; at rest it sends just the room
+outline. When the real-time map is absent we synthesize the base from the
+outline's low 2 bits (the same pixel-type nibble), so a floor plan renders either
+way.
+"""
+
+from __future__ import annotations
+
+from ...proto.cloud.p2pdata_pb2 import MapInfo
+from ..map_stream import MapData, _lz4_block_decompress, _quad_points, _ROOM_SCENE_NAMES
+from .mapdata import _decode_delimited, _iter_objects, _MAP_STREAM
+
+
+def _decompress(pixels) -> bytes:
+    if len(pixels.pixels) != pixels.pixel_size:
+        return _lz4_block_decompress(pixels.pixels, pixels.pixel_size)
+    return pixels.pixels
+
+
+def _pack_2bit(outline: bytes) -> bytes:
+    """Pack the outline's low-2-bit pixel type into the renderer's 4-px-per-byte base."""
+    packed = bytearray((len(outline) + 3) // 4)
+    for i, byte in enumerate(outline):
+        packed[i >> 2] |= (byte & 3) << ((i & 3) * 2)
+    return bytes(packed)
+
+
+def build_map_data(stream: bytes) -> MapData | None:
+    """Assemble a ``MapData`` from the conversation-5 byte stream, or None."""
+    outline: bytes | None = None
+    ow = oh = oox = ooy = 0
+    realtime: bytes | None = None
+    rw = rh = rox = roy = 0
+    room_names: dict[int, str] = {}
+    virtual_walls: list = []
+    forbidden_zones: list = []
+    ban_mop_zones: list = []
+
+    for name, obj in _iter_objects(stream):
+        if name != _MAP_STREAM:
+            continue
+        try:
+            info = _decode_delimited(obj).map_info
+        except Exception:  # noqa: BLE001 - skip anything that is not a whole MapChannelMsg
+            continue
+        kind = info.msg_type
+        if kind == MapInfo.MAP_ROOMOUTLINE and info.pixels.pixel_size:
+            outline = _decompress(info.pixels)
+            ow, oh, oox, ooy = info.map_width, info.map_height, info.origin.x, info.origin.y
+        elif kind == MapInfo.MAP_REALTIME and info.pixels.pixel_size:
+            realtime = _decompress(info.pixels)
+            rw, rh, rox, roy = info.map_width, info.map_height, info.origin.x, info.origin.y
+        elif kind == MapInfo.ROOM_PARAMS:
+            for room in info.room_params.rooms:
+                room_names[room.id] = room.name.strip() or _ROOM_SCENE_NAMES.get(
+                    room.scene.type, f"ROOM {room.id}"
+                )
+        elif kind == MapInfo.RESTRICT_ZONES:
+            zones = info.restricted_zones
+            virtual_walls += [((w.p0.x, w.p0.y), (w.p1.x, w.p1.y)) for w in zones.virtual_walls]
+            forbidden_zones += [_quad_points(z) for z in zones.forbidden_zones]
+            ban_mop_zones += [_quad_points(z) for z in zones.ban_mop_zones]
+
+    if realtime is not None:
+        base, width, height, ox, oy = realtime, rw, rh, rox, roy
+    elif outline is not None:
+        base, width, height, ox, oy = _pack_2bit(outline), ow, oh, oox, ooy
+    else:
+        return None
+
+    return MapData(
+        raw_pixels=base,
+        width=width,
+        height=height,
+        origin_x=ox,
+        origin_y=oy,
+        resolution=5,
+        room_pixels=outline,
+        room_outline_width=ow,
+        room_outline_height=oh,
+        room_outline_origin_x=oox,
+        room_outline_origin_y=ooy,
+        room_names=room_names,
+        virtual_walls=virtual_walls,
+        forbidden_zones=forbidden_zones,
+        ban_mop_zones=ban_mop_zones,
+    )

--- a/custom_components/robovac_mqtt/api/p2p/session.py
+++ b/custom_components/robovac_mqtt/api/p2p/session.py
@@ -64,7 +64,7 @@ class _UdpProtocol(asyncio.DatagramProtocol):
         self._queue.put_nowait(data)
 
 
-async def fetch_rooms(
+async def fetch_snapshot(
     host: str,
     local_key: str,
     device_id: str,
@@ -74,14 +74,17 @@ async def fetch_rooms(
     ice_config: dict | None = None,
     host_ip: str | None = None,
     timeout: float = 20.0,
-) -> list[dict]:
-    """Open a P2P session to ``host`` and return ``[{"id", "name"}, ...]``.
+    grace: float = 1.5,
+) -> bytes:
+    """Open a P2P session to ``host`` and return the conversation-5 byte stream.
 
     ``user_id`` is the account identity the offer is sent as. ``device_password``
     is the RTC-config password used to derive the conversation-0 credential.
     ``ice_config`` supplies the offer's ``token`` / ``tcp_token`` / ``log`` from
     the RTC config; without its ICE servers the device answers but never gathers
-    its host candidate. Raises :class:`TimeoutError` if the map does not arrive.
+    its host candidate. The device pushes the whole map in one burst; we keep
+    collecting for ``grace`` seconds after the first map segment, then return the
+    reassembled stream. Raises :class:`TimeoutError` if no map arrives.
     """
     key = local_key.encode()
     media_key = os.urandom(16)
@@ -168,9 +171,17 @@ async def fetch_rooms(
                         state["robot_addr"] = (match.group(1), int(match.group(2)))
                         send_udp(stun.binding_request(ufrag, state["robot_ufrag"], state["robot_pwd"], False))
 
-    async def media() -> list[dict]:
+    def assembled() -> bytes:
+        return b"".join(conv5[sn] for sn in sorted(conv5))
+
+    async def media() -> bytes:
+        deadline: float | None = None
         while True:
-            datagram = await udp_queue.get()
+            wait = None if deadline is None else max(0.0, deadline - loop.time())
+            try:
+                datagram = await asyncio.wait_for(udp_queue.get(), wait)
+            except asyncio.TimeoutError:
+                return assembled()  # grace elapsed after the map burst
             if stun.is_stun(datagram):
                 if stun.message_type(datagram) == stun.BIND_REQUEST and state["robot_addr"]:
                     send_udp(stun.binding_success(datagram, state["robot_addr"][0], state["robot_addr"][1], password.encode()))
@@ -189,10 +200,8 @@ async def fetch_rooms(
                 conv5[segment.sequence] = kcp.decrypt_record(media_key, segment.data)
                 while receive_next[kcp.CONV_MAP] in conv5:
                     receive_next[kcp.CONV_MAP] += 1
-                rooms = extract_rooms(b"".join(conv5[sn] for sn in sorted(conv5)))
-                if rooms is not None:
-                    _LOGGER.debug("p2p: extracted %d rooms", len(rooms))
-                    return rooms
+                if deadline is None:
+                    deadline = loop.time() + grace
 
     async def signaling_guard() -> None:
         try:
@@ -211,3 +220,8 @@ async def fetch_rooms(
             await writer.wait_closed()
         except Exception:  # noqa: BLE001 - closing a half-open socket may raise
             pass
+
+
+async def fetch_rooms(*args, **kwargs) -> list[dict]:
+    """Open a P2P session and return ``[{"id", "name"}, ...]`` (empty if none)."""
+    return extract_rooms(await fetch_snapshot(*args, **kwargs)) or []

--- a/custom_components/robovac_mqtt/api/p2p/session.py
+++ b/custom_components/robovac_mqtt/api/p2p/session.py
@@ -1,0 +1,213 @@
+"""Drive one P2P session on the LAN and return the room list.
+
+Ties the pieces together: signaling over TCP 6668, ICE and the tagged KCP media
+over a UDP pair, the conversation-0 control burst, then reassembly of the
+conversation-5 map stream into the rooms. Everything is generated fresh (our own
+AES media key); nothing from a prior capture is reused except the fixed,
+secret-free control packets in :mod:`control`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import secrets
+import socket
+import time
+
+from . import control, kcp, stun
+from .framing import CMD_DP_QUERY, CMD_RTC, decode_frames, encode_frame
+from .mapdata import extract_rooms
+
+_LOGGER = logging.getLogger(__name__)
+
+ROBOT_PORT = 6668
+_ALNUM = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+_DEFAULT_LOG = {"api": "thing.m.rtc.log", "interval": 60, "size": 1024, "level": 2, "topic": "/av/moto/log"}
+
+
+def _random(length: int) -> str:
+    return "".join(secrets.choice(_ALNUM) for _ in range(length))
+
+
+def _build_offer_sdp(session_id: str, ufrag: str, password: str, aes_key_hex: str, cname: str) -> str:
+    return "\r\n".join(
+        (
+            "v=0",
+            f"o=- {int(time.time())} 1 IN IP4 127.0.0.1",
+            "s=-",
+            "t=0 0",
+            "a=group:BUNDLE imm0",
+            f"a=msid-semantic: WMS {session_id}",
+            "m=application 9 imm 6001",
+            "c=IN IP4 0.0.0.0",
+            "a=rtcp:9 IN IP4 0.0.0.0",
+            f"a=ice-ufrag:{ufrag}",
+            f"a=ice-pwd:{password}",
+            "a=ice-options:trickle",
+            f"a=aes-key:{aes_key_hex}",
+            "a=mid:imm0",
+            "a=rtpmap:6001 AES/KCP 330",
+            f"a=ssrc:0 cname:{cname}",
+            "",
+        )
+    )
+
+
+class _UdpProtocol(asyncio.DatagramProtocol):
+    def __init__(self, queue: asyncio.Queue) -> None:
+        self._queue = queue
+
+    def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
+        self._queue.put_nowait(data)
+
+
+async def fetch_rooms(
+    host: str,
+    local_key: str,
+    device_id: str,
+    user_id: str,
+    device_password: str,
+    *,
+    ice_config: dict | None = None,
+    host_ip: str | None = None,
+    timeout: float = 20.0,
+) -> list[dict]:
+    """Open a P2P session to ``host`` and return ``[{"id", "name"}, ...]``.
+
+    ``user_id`` is the account identity the offer is sent as. ``device_password``
+    is the RTC-config password used to derive the conversation-0 credential.
+    ``ice_config`` supplies the offer's ``token`` / ``tcp_token`` / ``log`` from
+    the RTC config; without its ICE servers the device answers but never gathers
+    its host candidate. Raises :class:`TimeoutError` if the map does not arrive.
+    """
+    key = local_key.encode()
+    media_key = os.urandom(16)
+    media_key_hex = media_key.hex()
+    ufrag, password = _random(4), _random(24)
+    session_id = f"{device_id}{int(time.time())}{_random(8)}"
+    trace_id = f"ipc_p2p_ios_{device_id}_{int(time.time())}000"
+    cfg = ice_config or {}
+
+    loop = asyncio.get_running_loop()
+    udp_queue: asyncio.Queue = asyncio.Queue()
+    if host_ip is None:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as probe:
+            probe.connect((host, ROBOT_PORT))
+            host_ip = probe.getsockname()[0]
+    transport, _ = await loop.create_datagram_endpoint(lambda: _UdpProtocol(udp_queue), local_addr=(host_ip, 0))
+    our_udp_port = transport.get_extra_info("sockname")[1]
+
+    reader, writer = await asyncio.open_connection(host, ROBOT_PORT)
+    state: dict = {"robot_ufrag": None, "robot_pwd": None, "robot_addr": None, "ice_up": False, "conv0_sent": False}
+    conv5: dict[int, bytes] = {}
+    receive_next = {kcp.CONV_CONTROL: 0, kcp.CONV_MAP: 0}
+
+    def send_udp(datagram: bytes) -> None:
+        if state["robot_addr"]:
+            transport.sendto(datagram, state["robot_addr"])
+
+    def send_conv0() -> None:
+        if state["conv0_sent"]:
+            return
+        state["conv0_sent"] = True
+        for sequence, packet in enumerate(control.start_packets(device_password, local_key)):
+            send_udp(kcp.build_push(media_key, kcp.CONV_CONTROL, sequence, packet))
+
+    async def signaling() -> None:
+        sequence = 1
+        writer.write(encode_frame(key, CMD_DP_QUERY, {"gwId": device_id, "devId": device_id}, sequence))
+        sequence += 1
+        offer = {
+            "msg": {
+                "sdp": _build_offer_sdp(session_id, ufrag, password, media_key_hex, user_id),
+                "preconnect": True,
+                "token": cfg.get("token", []),
+                "tcp_token": cfg.get("tcp_token", {}),
+                "log": cfg.get("log", _DEFAULT_LOG),
+            },
+            "header": {
+                "from": user_id, "sessionid": session_id, "is_pre": 0, "p2p_skill": 67,
+                "path": "lan", "security_level": 3, "type": "offer", "to": device_id,
+                "moto_id": "", "trace_id": trace_id,
+            },
+        }
+        writer.write(encode_frame(key, CMD_RTC, offer, sequence))
+        sequence += 1
+        candidate = {
+            "msg": {"candidate": f"a=candidate:{secrets.randbelow(2_000_000_000)} 1 UDP 2130706431 {host_ip} {our_udp_port} typ host\r\n"},
+            "header": {"from": user_id, "sessionid": session_id, "path": "lan", "sub_dev_id": "", "type": "candidate", "to": device_id, "trace_id": trace_id},
+        }
+        await writer.drain()
+        await asyncio.sleep(0.4)
+        writer.write(encode_frame(key, CMD_RTC, candidate, sequence))
+        await writer.drain()
+        _LOGGER.debug("p2p: offer and candidate sent to %s", host)
+
+        buffer = b""
+        while True:
+            chunk = await reader.read(65536)
+            if not chunk:
+                return
+            buffer += chunk
+            frames, buffer = decode_frames(key, buffer)
+            for command, payload in frames:
+                if command != CMD_RTC or not isinstance(payload, dict):
+                    continue
+                header, msg = payload.get("header", {}), payload.get("msg", {})
+                if header.get("type") == "answer":
+                    sdp = msg.get("sdp", "")
+                    state["robot_ufrag"] = (re.search(r"ice-ufrag:(\S+)", sdp) or [None, None])[1]
+                    pwd = re.search(r"ice-pwd:(\S+)", sdp)
+                    state["robot_pwd"] = pwd.group(1).encode() if pwd else None
+                elif header.get("type") == "candidate":
+                    match = re.search(r"(\d+\.\d+\.\d+\.\d+) (\d+) typ host", msg.get("candidate", ""))
+                    if match and match.group(1) == host and state["robot_pwd"]:
+                        state["robot_addr"] = (match.group(1), int(match.group(2)))
+                        send_udp(stun.binding_request(ufrag, state["robot_ufrag"], state["robot_pwd"], False))
+
+    async def media() -> list[dict]:
+        while True:
+            datagram = await udp_queue.get()
+            if stun.is_stun(datagram):
+                if stun.message_type(datagram) == stun.BIND_REQUEST and state["robot_addr"]:
+                    send_udp(stun.binding_success(datagram, state["robot_addr"][0], state["robot_addr"][1], password.encode()))
+                    if not state["ice_up"]:
+                        state["ice_up"] = True
+                        _LOGGER.debug("p2p: ICE connected, opening control channel")
+                        send_udp(stun.binding_request(ufrag, state["robot_ufrag"], state["robot_pwd"], True))
+                        loop.call_later(0.3, send_conv0)
+                continue
+            for segment in kcp.parse_datagram(datagram):
+                if segment.command != kcp.CMD_PUSH:
+                    continue
+                send_udp(kcp.build_ack(segment.conversation, segment.sequence, receive_next[segment.conversation]))
+                if segment.conversation != kcp.CONV_MAP:
+                    continue
+                conv5[segment.sequence] = kcp.decrypt_record(media_key, segment.data)
+                while receive_next[kcp.CONV_MAP] in conv5:
+                    receive_next[kcp.CONV_MAP] += 1
+                rooms = extract_rooms(b"".join(conv5[sn] for sn in sorted(conv5)))
+                if rooms is not None:
+                    _LOGGER.debug("p2p: extracted %d rooms", len(rooms))
+                    return rooms
+
+    async def signaling_guard() -> None:
+        try:
+            await signaling()
+        except Exception:  # noqa: BLE001 - surface signaling failures without killing the media wait
+            _LOGGER.exception("p2p: signaling failed")
+
+    signaling_task = asyncio.ensure_future(signaling_guard())
+    try:
+        return await asyncio.wait_for(media(), timeout)
+    finally:
+        signaling_task.cancel()
+        transport.close()
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:  # noqa: BLE001 - closing a half-open socket may raise
+            pass

--- a/custom_components/robovac_mqtt/api/p2p/stun.py
+++ b/custom_components/robovac_mqtt/api/p2p/stun.py
@@ -1,0 +1,95 @@
+"""The little STUN/ICE this client needs to satisfy the device's connectivity checks.
+
+The device runs a normal ICE agent with short-term credentials and will not open
+the data channel until connectivity is confirmed in both directions. We answer
+its binding requests and send our own; MESSAGE-INTEGRITY is HMAC-SHA1 keyed by
+the checked side's ICE password and FINGERPRINT is CRC32 xor ``0x5354554e``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import struct
+import zlib
+
+MAGIC_COOKIE = 0x2112A442
+_MAGIC = MAGIC_COOKIE.to_bytes(4, "big")
+
+BIND_REQUEST = 0x0001
+BIND_SUCCESS = 0x0101
+
+_ATTR_USERNAME = 0x0006
+_ATTR_MESSAGE_INTEGRITY = 0x0008
+_ATTR_XOR_MAPPED_ADDRESS = 0x0020
+_ATTR_PRIORITY = 0x0024
+_ATTR_USE_CANDIDATE = 0x0025
+_ATTR_ICE_CONTROLLING = 0x002A
+_ATTR_FINGERPRINT = 0x8028
+_ATTR_SOFTWARE = 0x8022
+
+_SOFTWARE = b"tuya_p2p_sdk_v3.4.3\x00"
+
+
+def _attribute(attr_type: int, value: bytes) -> bytes:
+    pad = (4 - len(value) % 4) % 4
+    return struct.pack(">HH", attr_type, len(value)) + value + b"\x00" * pad
+
+
+def _xor_mapped_address(ip: str, port: int) -> bytes:
+    body = bytearray(8)
+    body[1] = 0x01
+    struct.pack_into(">H", body, 2, port ^ 0x2112)
+    for i, octet in enumerate(ip.split(".")):
+        body[4 + i] = int(octet) ^ _MAGIC[i]
+    return bytes(body)
+
+
+def build_message(message_type: int, transaction_id: bytes, attributes: list[bytes], integrity_key: bytes | None) -> bytes:
+    """Build a STUN message, appending MESSAGE-INTEGRITY then FINGERPRINT."""
+    body = b"".join(attributes)
+    if integrity_key is not None:
+        header = struct.pack(">HH", message_type, len(body) + 24) + _MAGIC + transaction_id
+        mac = hmac.new(integrity_key, header + body, hashlib.sha1).digest()
+        body += _attribute(_ATTR_MESSAGE_INTEGRITY, mac)
+    header = struct.pack(">HH", message_type, len(body) + 8) + _MAGIC + transaction_id
+    fingerprint = (zlib.crc32(header + body) & 0xFFFFFFFF) ^ 0x5354554E
+    body += _attribute(_ATTR_FINGERPRINT, struct.pack(">I", fingerprint))
+    return struct.pack(">HH", message_type, len(body)) + _MAGIC + transaction_id + body
+
+
+def is_stun(datagram: bytes) -> bool:
+    return len(datagram) >= 20 and datagram[4:8] == _MAGIC
+
+
+def message_type(datagram: bytes) -> int:
+    return int.from_bytes(datagram[0:2], "big")
+
+
+def transaction_id(datagram: bytes) -> bytes:
+    return datagram[8:20]
+
+
+def binding_success(request: bytes, source_ip: str, source_port: int, our_ice_password: bytes) -> bytes:
+    """Answer a device binding request from ``source`` with a success response."""
+    return build_message(
+        BIND_SUCCESS,
+        transaction_id(request),
+        [_attribute(_ATTR_XOR_MAPPED_ADDRESS, _xor_mapped_address(source_ip, source_port)), _attribute(_ATTR_SOFTWARE, _SOFTWARE)],
+        our_ice_password,
+    )
+
+
+def binding_request(local_ufrag: str, remote_ufrag: str, remote_ice_password: bytes, nominate: bool) -> bytes:
+    """Build a binding request toward the device, optionally nominating."""
+    tid = b"AYUT" + os.urandom(8)
+    attributes = [
+        _attribute(_ATTR_USERNAME, f"{remote_ufrag}:{local_ufrag}".encode()),
+        _attribute(_ATTR_PRIORITY, b"\x6e\xff\xff\xff"),
+        _attribute(_ATTR_ICE_CONTROLLING, b"\xff\xff\xff\xff" + os.urandom(4)),
+    ]
+    if nominate:
+        attributes.append(_attribute(_ATTR_USE_CANDIDATE, b""))
+    attributes.append(_attribute(_ATTR_SOFTWARE, _SOFTWARE))
+    return build_message(BIND_REQUEST, tid, attributes, remote_ice_password)

--- a/custom_components/robovac_mqtt/api/tuya_cloud.py
+++ b/custom_components/robovac_mqtt/api/tuya_cloud.py
@@ -236,6 +236,27 @@ class TuyaCloudClient:
         _LOGGER.debug("Tuya get_device_list: total %d devices", len(all_devices))
         return all_devices
 
+    async def get_rtc_config(self, device_id: str) -> dict[str, Any] | None:
+        """Fetch the P2P/RTC config for one device.
+
+        Returns ``{"device_password", "ice_config"}`` where ``ice_config`` holds
+        the offer's ``token`` (the ICE servers), ``tcp_token`` and ``log``. The
+        conversation-0 credential is derived from ``device_password``; the ICE
+        servers are required for the device to gather its host candidate.
+        """
+        result = await self.request("m.ipc.v4.rtc.config.get", {"devId": device_id}, version="1.0")
+        if not result:
+            return None
+        p2p = result.get("p2pConfig", {}) or {}
+        return {
+            "device_password": result.get("password", ""),
+            "ice_config": {
+                "token": p2p.get("ices", []),
+                "tcp_token": p2p.get("tcpRelay", {}),
+                "log": p2p.get("log", {}),
+            },
+        }
+
     async def get_device(self, device_id: str) -> dict[str, Any] | None:
         """Poll a single device's state (DPS) from Tuya Cloud."""
         devices = await self.get_device_list()

--- a/custom_components/robovac_mqtt/coordinator.py
+++ b/custom_components/robovac_mqtt/coordinator.py
@@ -264,7 +264,7 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
         self.hass.async_create_task(self._async_load_p2p_rooms())
 
     async def _async_load_p2p_rooms(self) -> None:
-        """Fetch the room list over the local P2P map channel (Tuya devices).
+        """Fetch the room list and map over the local P2P channel (Tuya devices).
 
         Needs the RTC config (``device_password`` + ICE servers) from Tuya Cloud;
         without a Tuya cloud session it is skipped and manual overrides still work.
@@ -275,11 +275,13 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
         try:
             rtc = await tuya.get_rtc_config(self.device_id)
             if not rtc or not rtc.get("device_password"):
-                _LOGGER.debug("P2P rooms: no RTC config for %s", self.device_name)
+                _LOGGER.debug("P2P: no RTC config for %s", self.device_name)
                 return
-            from .api.p2p import fetch_rooms
+            from .api.p2p import fetch_snapshot
+            from .api.p2p.mapdata import extract_rooms
+            from .api.p2p.mapimage import build_map_data
 
-            rooms = await fetch_rooms(
+            stream = await fetch_snapshot(
                 host=self._local_host,
                 local_key=self._local_key,
                 device_id=self.device_id,
@@ -288,11 +290,19 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
                 ice_config=rtc.get("ice_config"),
             )
         except Exception as err:  # noqa: BLE001 - P2P is best-effort; never break the device
-            _LOGGER.debug("P2P room fetch failed for %s: %s", self.device_name, err)
+            _LOGGER.debug("P2P fetch failed for %s: %s", self.device_name, err)
             return
+        rooms = extract_rooms(stream) or []
         if rooms:
             _LOGGER.info("P2P: fetched %d rooms for %s", len(rooms), self.device_name)
             self.async_set_updated_data(replace(self.data, rooms=rooms))
+        map_data = build_map_data(stream)
+        if map_data is not None:
+            _LOGGER.info(
+                "P2P: rendered map for %s (%dx%d)", self.device_name, map_data.width, map_data.height
+            )
+            self._map_data = map_data
+            self._rerender_map()
 
     async def _initialize_mqtt(self) -> None:
         """Initialize MQTT connection."""

--- a/custom_components/robovac_mqtt/coordinator.py
+++ b/custom_components/robovac_mqtt/coordinator.py
@@ -259,6 +259,40 @@ class EufyCleanCoordinator(DataUpdateCoordinator[VacuumState]):
             await self._fall_back_to_cloud()
             return
         await self.async_load_storage()
+        # Rooms are not on any DPS for local Tuya devices; pull them once over the
+        # encrypted P2P channel in the background so the connect path is not blocked.
+        self.hass.async_create_task(self._async_load_p2p_rooms())
+
+    async def _async_load_p2p_rooms(self) -> None:
+        """Fetch the room list over the local P2P map channel (Tuya devices).
+
+        Needs the RTC config (``device_password`` + ICE servers) from Tuya Cloud;
+        without a Tuya cloud session it is skipped and manual overrides still work.
+        """
+        tuya = self.eufy_login.tuya_client
+        if not tuya or not self._local_key or not self._local_host:
+            return
+        try:
+            rtc = await tuya.get_rtc_config(self.device_id)
+            if not rtc or not rtc.get("device_password"):
+                _LOGGER.debug("P2P rooms: no RTC config for %s", self.device_name)
+                return
+            from .api.p2p import fetch_rooms
+
+            rooms = await fetch_rooms(
+                host=self._local_host,
+                local_key=self._local_key,
+                device_id=self.device_id,
+                user_id="homeassistant",
+                device_password=rtc["device_password"],
+                ice_config=rtc.get("ice_config"),
+            )
+        except Exception as err:  # noqa: BLE001 - P2P is best-effort; never break the device
+            _LOGGER.debug("P2P room fetch failed for %s: %s", self.device_name, err)
+            return
+        if rooms:
+            _LOGGER.info("P2P: fetched %d rooms for %s", len(rooms), self.device_name)
+            self.async_set_updated_data(replace(self.data, rooms=rooms))
 
     async def _initialize_mqtt(self) -> None:
         """Initialize MQTT connection."""

--- a/custom_components/robovac_mqtt/select.py
+++ b/custom_components/robovac_mqtt/select.py
@@ -147,10 +147,13 @@ async def async_setup_entry(
         if coordinator.connection_type == "mqtt":
             candidates.append(SceneSelectEntity(coordinator))
             candidates.append(MapSelectEntity(coordinator))
-        # Room list is normally P2P-only too, but the user can supply a
-        # manual {room_id: name} override through the options flow which
-        # works on every transport.
-        if coordinator.connection_type == "mqtt" or coordinator.room_name_overrides:
+        # The room list comes from MQTT, from the local P2P channel (Tuya
+        # devices, fetched by the coordinator), or from a manual
+        # {room_id: name} override supplied through the options flow.
+        if (
+            coordinator.connection_type in ("mqtt", "local")
+            or coordinator.room_name_overrides
+        ):
             candidates.append(RoomSelectEntity(coordinator))
 
         entities.extend(filter_supported_entities(coordinator, candidates))

--- a/docs/P2P_MAP_CHANNEL.md
+++ b/docs/P2P_MAP_CHANNEL.md
@@ -1,0 +1,126 @@
+# The encrypted P2P map channel
+
+On Tuya-transport robots (`mqtt=False`, e.g. Eufy S1 Pro / T2080A) the map, the
+**room list with names**, obstacles, live position and current target are not on
+any DPS and never reach the `biz/` MQTT stream. The app reads them over a local,
+encrypted Tuya **P2P** channel. A client can open that channel itself on the LAN
+with only the device local key.
+
+> [!NOTE]
+> Verified end to end on an **Eufy S1 Pro (T2080A), fw 7.0.170**, local Tuya
+> (protocol 3.3). Protobuf schemas are already bundled in
+> `custom_components/robovac_mqtt/proto/cloud/`.
+
+## Why P2P is the only source
+
+| Source | On this device |
+| --- | --- |
+| DPS 165 `MAP_DATA` (`RoomParams`) | Not emitted (a full `DP_QUERY` returns only small legacy DPS) |
+| MQTT `biz/` (plaintext protobuf) | Never published: the device is not MQTT-connected (issue #131) |
+| P2P | The only channel that carries rooms |
+
+## Transport
+
+```
+TCP 6668, Tuya protocol 3.3 (frames encrypted with the local key)
+  command type 32 = signaling: SDP offer/answer + ICE candidates
+    the SDP carries  a=aes-key:<32 hex>  = the session key, CHOSEN BY THE OFFERER
+
+UDP on the LAN, client <-> device
+  STUN/ICE (short-term creds), then KCP segments
+    conv 0 = control (auth + subscribe)
+    conv 5 = map (device pushes it)
+```
+
+Two layers: the Tuya local layer protects the type-32 signaling (so `a=aes-key`
+is readable); the P2P layer (AES-128-CBC with that key) protects the UDP media.
+
+> [!NOTE]
+> Type-32 frames have **no** "3.3" extended header, unlike DP writes. Encrypt the
+> payload without it, or the device answers `"parse data error"`.
+
+## KCP segment and the integrity tag
+
+```
+[ header(24) ] [ data = IV(16) | AES-CBC ciphertext ] [ HMAC-SHA1(media_key, header+data) = 20 bytes ]
+               \_______ KCP len bytes ______________/
+```
+
+- `media_key` = the session AES key. The tag covers the whole segment.
+- The device silently drops any data segment with a missing or wrong tag: `una`
+  never advances, nothing comes back.
+- ACKs (`cmd 0x52`, `len 0`, 24 bytes) carry no tag.
+- KCP `len` **includes** the 16-byte IV, so `ciphertext = len - 16`. Read `len`
+  as ciphertext-only and the last block decrypts to garbage and 4 bytes look like
+  a trailer. There is no 4-byte trailer.
+
+Header, little-endian: `conv u32 | cmd u8 | frg u8 | wnd u16 | ts u32 | sn u32 |
+una u32 | len u32`. `cmd`: `0x51` PUSH, `0x52` ACK.
+
+> [!NOTE]
+> Same framing as the PyPI package
+> [`tuya-ipc-p2p-sdk`](https://pypi.org/project/tuya-ipc-p2p-sdk/)
+> (`transport/relay_framing.py`, `crypto.py`). It targets the TCP relay; the
+> direct-LAN payload is the `segment | tag` above, no `f6` wrapper.
+
+## Control channel (conv 0)
+
+The client sends a burst of KCP PUSH records. The first is the auth packet:
+
+```
+magic u32 = 0x12345678 | type u32 = 1 | username[32]="admin" | credential[32] | reserved[32]
+credential = md5_hex(f"{device_password}||{local_key}")
+```
+
+`device_password` is the `password` field of the Tuya RTC config
+(`m.ipc.v4.rtc.config.get`); it is stable per device. After auth, a fixed set of
+control commands follows; the device answers on conv 0, then streams conv 5.
+Reference: `control.py` in `tuya-ipc-p2p-sdk`.
+
+## Map channel (conv 5)
+
+The conv-5 stream is chunks: an 80-byte header then payload. Header fields
+(little-endian): const `1`, const `1000`, session counter (u16 @8), chunk index
+(u32 @12), stream name (48 bytes @20, e.g. `map.bin.stream`), payload len (@68),
+total len (@72), single-chunk flag (@76). Concatenate chunk payloads of one
+stream name up to `total`. Each `map.bin.stream` object is a length-delimited
+`MapChannelMsg`, keyed by `map_info.msg_type`:
+
+| `msg_type` | Field | Content |
+| --- | --- | --- |
+| `MAP_ROOMOUTLINE` | `pixels` | LZ4 room bitmap |
+| `ROOM_PARAMS` | `room_params` | **Room list**: `rooms[]` with `id`, `name`, `custom` |
+| `OBSTACLE_INFO` | `obstacles` | Objects + coordinates |
+| `RESTRICT_ZONES` | `restricted_zones` | Virtual walls / no-go |
+| `TEMPORARY_DATA` | `temporary_data` | Current selection (`select_rooms_clean`) |
+
+`ROOM_PARAMS.map_id` is the **local** map id (small saved-map index, `1` for the
+first map), the id the firmware accepts in room-clean commands.
+
+## Initiation recipe
+
+1. Open TCP 6668, protocol 3.3, local key.
+2. Generate the AES media key, ICE ufrag/pwd, a `sessionid`/`trace_id`.
+3. Send a type-32 **offer** (no 3.3 header): our SDP (`a=aes-key`, `path:lan`),
+   `msg` with `token`/`tcp_token`/`log` (synthetic is fine on the LAN). The device
+   answers and echoes our key.
+4. Send a type-32 **candidate** with our host candidate. The device sends its own.
+5. **ICE**: answer the device's STUN binds (Binding Success + XOR-MAPPED +
+   MESSAGE-INTEGRITY keyed by *our* ice-pwd + FINGERPRINT), send ours (integrity
+   keyed by the *device* ice-pwd) with USE-CANDIDATE.
+6. Send the **conv-0** burst (tagged PUSH), starting with the auth packet.
+7. ACK the device's conv-5 PUSH. Reassemble by sn, decrypt each record, split into
+   chunks, decode `MapChannelMsg`. `ROOM_PARAMS` gives the rooms.
+
+## Security
+
+Trusted-LAN only, like the rest of the local Tuya transport. The local key and
+`device_password` are secrets; never log them. Opening the session is what the
+app does on its map view; it does not move the robot.
+
+## What this unlocks
+
+For `mqtt=False` devices, none of this is otherwise reachable without the app:
+room list with names, live map image, live position/path, obstacles, restricted
+zones, and the robot-side current target (`TEMPORARY_DATA`). All local, no cloud.
+Room *cleaning* already works over local DPS and does not need this channel.

--- a/tests/test_p2p.py
+++ b/tests/test_p2p.py
@@ -1,0 +1,121 @@
+"""Unit tests for the local P2P client (api/p2p): framing, KCP tag, rooms."""
+
+import hashlib
+import hmac
+import struct
+
+from google.protobuf.internal import encoder
+
+from custom_components.robovac_mqtt.api.p2p import control, framing, kcp, mapdata, stun
+from custom_components.robovac_mqtt.proto.cloud.p2pdata_pb2 import MapChannelMsg, MapInfo
+
+_KEY = b"0123456789abcdef"
+
+
+def test_auth_credential_formula():
+    """The conversation-0 token is md5(password + '||' + localKey)."""
+    assert control.auth_credential("pw", "lk") == hashlib.md5(b"pw||lk").hexdigest()
+
+
+def test_auth_packet_layout():
+    """Auth packet: magic, type 0, 'admin', then the credential at offset 40."""
+    credential = "a" * 32
+    packet = control._auth_packet(credential)
+    assert len(packet) == 104
+    assert packet[0:4] == b"\x78\x56\x34\x12"
+    assert packet[4:8] == b"\x00\x00\x00\x00"
+    assert packet[8:13] == b"admin"
+    assert packet[40:72] == credential.encode()
+
+
+def test_kcp_push_is_tagged_and_roundtrips():
+    """A PUSH segment ends with HMAC-SHA1(media_key, segment) and decrypts back."""
+    plaintext = b"hello world payload"
+    datagram = kcp.build_push(_KEY, kcp.CONV_CONTROL, 7, plaintext)
+    length = struct.unpack("<I", datagram[20:24])[0]
+    segment, tag = datagram[: 24 + length], datagram[24 + length :]
+    assert tag == hmac.new(_KEY, segment, hashlib.sha1).digest()
+    assert len(tag) == kcp.TAG_LENGTH
+    [parsed] = kcp.parse_datagram(datagram)
+    assert parsed.command == kcp.CMD_PUSH
+    assert parsed.sequence == 7
+    assert kcp.decrypt_record(_KEY, parsed.data) == plaintext
+
+
+def test_kcp_ack_has_no_tag():
+    """An ACK is a bare 24-byte header with sn and una set."""
+    ack = kcp.build_ack(kcp.CONV_MAP, 3, 4)
+    assert len(ack) == kcp.HEADER_LENGTH
+    conv, cmd, _frg, _wnd, _ts, sn, una, length = struct.unpack("<IBBHIIII", ack)
+    assert (conv, cmd, sn, una, length) == (kcp.CONV_MAP, kcp.CMD_ACK, 3, 4, 0)
+
+
+def test_framing_roundtrip():
+    """A type-32 frame encodes and decodes back to the same JSON."""
+    payload = {"header": {"type": "offer"}, "msg": {"sdp": "v=0"}}
+    frame = framing.encode_frame(_KEY, framing.CMD_RTC, payload, 3)
+    frames, tail = framing.decode_frames(_KEY, frame)
+    assert tail == b""
+    assert frames == [(framing.CMD_RTC, payload)]
+
+
+def test_framing_strips_device_return_code():
+    """Device frames carry a 4-byte return code before the ciphertext."""
+    payload = {"msg": {"candidate": ""}}
+    frame = bytearray(framing.encode_frame(_KEY, framing.CMD_RTC, payload, 1))
+    # Splice a zero return code in front of the ciphertext and fix the length.
+    length = int.from_bytes(frame[12:16], "big")
+    frame[12:16] = (length + 4).to_bytes(4, "big")
+    frame[16:16] = b"\x00\x00\x00\x00"
+    frames, _ = framing.decode_frames(_KEY, bytes(frame))
+    assert frames[0][1] == payload
+
+
+def test_stun_fingerprint_is_valid():
+    """binding_request ends with a correct FINGERPRINT attribute."""
+    import zlib
+
+    message = stun.binding_request("abcd", "wxyz", b"pwd", nominate=True)
+    assert stun.is_stun(message)
+    fingerprint = struct.unpack(">I", message[-4:])[0]
+    assert fingerprint == (zlib.crc32(message[:-8]) & 0xFFFFFFFF) ^ 0x5354554E
+
+
+def _delimited(message) -> bytes:
+    body = message.SerializeToString()
+    return encoder._VarintBytes(len(body)) + body
+
+
+def _chunk(name: bytes, payload: bytes) -> bytes:
+    header = bytearray(80)
+    struct.pack_into("<II", header, 0, 1, 1000)
+    struct.pack_into("<H", header, 8, 1)
+    struct.pack_into("<H", header, 10, 1)
+    header[20 : 20 + len(name)] = name
+    struct.pack_into("<III", header, 68, len(payload), len(payload), 1)
+    return bytes(header) + payload
+
+
+def test_extract_rooms_keeps_room_zero():
+    """extract_rooms decodes ROOM_PARAMS and preserves room id 0."""
+    message = MapChannelMsg()
+    message.type = MapChannelMsg.MAP_INFO
+    message.map_info.msg_type = MapInfo.ROOM_PARAMS
+    for room_id, name in ((0, "Kitchen"), (5, "")):
+        room = message.map_info.room_params.rooms.add()
+        room.id = room_id
+        room.name = name
+    stream = _chunk(b"map.bin.stream", _delimited(message))
+    assert mapdata.extract_rooms(stream) == [
+        {"id": 0, "name": "Kitchen"},
+        {"id": 5, "name": ""},
+    ]
+
+
+def test_extract_rooms_none_without_room_params():
+    """A stream with no ROOM_PARAMS object returns None."""
+    message = MapChannelMsg()
+    message.type = MapChannelMsg.MAP_INFO
+    message.map_info.msg_type = MapInfo.OBSTACLE_INFO
+    stream = _chunk(b"map.bin.stream", _delimited(message))
+    assert mapdata.extract_rooms(stream) is None


### PR DESCRIPTION
## What

Adds the room list (with names) and the live floor map for `mqtt=False` devices like the S1 Pro. These devices expose neither on any DPS nor on the `biz/` MQTT stream, so today the room dropdown is empty and the map camera stays blank.

<img width="3008" height="1300" alt="image" src="https://github.com/user-attachments/assets/25a6fd9c-4675-48dd-bb17-24caf71d4247" />


## How

- New `api/p2p/`: opens the encrypted Tuya P2P map channel on the LAN with the device local key, runs the ICE/KCP handshake, and decodes the map stream. Pure asyncio, no new dependency. The channel and how to open it are documented in `docs/P2P_MAP_CHANNEL.md`.
- The coordinator fetches the RTC config (`device_password` + ICE servers) from Tuya Cloud, runs one P2P session in the background on local connect, then:
  - fills `data.rooms` (room select enabled for local devices);
  - builds a `MapData` and feeds the existing map camera, so `camera.<device>_map` now works on local Tuya devices too.

## Tested

- End to end on an S1 Pro (T2080A, fw 7.0.170): 8 rooms and the rendered floor map show up live in HA, using the Tuya Cloud RTC config and LAN P2P, no capture involved.
- Unit tests in `tests/test_p2p.py`: framing, KCP tag, room decode (keeps room id 0).

## Notes

- The device streams the real-time map only while moving; at rest it sends the room outline, which is enough to render a floor plan (the base is synthesized from it).
- Live robot position and cleaning path ride the same channel and could follow.
